### PR TITLE
added 'open' and 'topUp' with assets functions to YieldStreaming contract

### DIFF
--- a/src/YieldStreaming.sol
+++ b/src/YieldStreaming.sol
@@ -135,9 +135,7 @@ contract YieldStreaming is ERC721, Multicall {
         public
         returns (uint256 streamId)
     {
-        uint256 principal = _convertToAssets(_shares);
-
-        _canOpen(_receiver, _shares, principal, _maxLossOnOpenTolerancePercent);
+        uint256 principal = previewOpen(_receiver, _shares, _maxLossOnOpenTolerancePercent);
 
         streamId = _openStream(_receiver, _shares, principal);
 

--- a/src/YieldStreaming.sol
+++ b/src/YieldStreaming.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import {Multicall} from "openzeppelin-contracts/utils/Multicall.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
 import {IERC2612} from "openzeppelin-contracts/interfaces/IERC2612.sol";
 import {ERC721} from "openzeppelin-contracts/token/ERC721/ERC721.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
@@ -20,108 +21,152 @@ import {AddressZero, AmountZero} from "./common/Errors.sol";
 contract YieldStreaming is ERC721, Multicall {
     using FixedPointMathLib for uint256;
     using SafeERC20 for IERC4626;
+    using SafeERC20 for IERC20;
 
     error NoYieldToClaim();
     error LossToleranceExceeded();
     error CallerNotOwner();
 
+    /**
+     * @notice Emitted when a new yield stream is opened between a streamer and a receiver.
+     * @param streamId The unique identifier for the newly opened yield stream, represented by an ERC721 token.
+     * @param streamer The address of the streamer who opened the yield stream.
+     * @param receiver The address of the receiver for the yield stream.
+     * @param shares The number of shares allocated to the new yield stream.
+     * @param principal The principal amount in asset units, ie the value of the shares at the time of opening the stream.
+     */
     event Open(
         uint256 indexed streamId, address indexed streamer, address indexed receiver, uint256 shares, uint256 principal
     );
+
+    /**
+     * @notice Emitted when additional shares are added to an existing yield stream.
+     * @param streamId The unique identifier of the yield stream (ERC721 token) to which shares are added.
+     * @param streamer The address of the streamer who added the shares to the yield stream.
+     * @param receiver The address of the receiver for the yield stream.
+     * @param shares The number of additional shares added to the yield stream.
+     * @param principal The principal amount in asset units, ie the value of the shares at the time of the addition.
+     */
     event TopUp(
         uint256 indexed streamId, address indexed streamer, address indexed receiver, uint256 shares, uint256 principal
     );
+
+    /**
+     * @notice Emitted when the yield generated from a stream is claimed by the receiver and transferred to a specified address.
+     * @param receiver The address of the receiver for the yield stream.
+     * @param claimedTo The address where the claimed yield is sent.
+     * @param sharesRedeemed The number of shares redeemed as yield.
+     * @param yield The total amount of assets claimed as realized yield.
+     */
     event ClaimYield(address indexed receiver, address indexed claimedTo, uint256 sharesRedeemed, uint256 yield);
+
+    /**
+     * @notice Emitted when the yield generated from a stream is claimed by the receiver and transferred in shares to a specified address.
+     * @param receiver The address of the receiver for the yield stream.
+     * @param claimedTo The address where the claimed yield shares are sent.
+     * @param yieldInShares The total number of shares claimed as yield.
+     */
     event ClaimYieldInShares(address indexed receiver, address indexed claimedTo, uint256 yieldInShares);
+
+    /**
+     * @notice Emitted when a yield stream is closed, returning the remaining shares to the streamer.
+     * @param streamId The unique identifier of the yield stream that is being closed, represented by an ERC721 token.
+     * @param streamer The address of the streamer who is closing the yield stream.
+     * @param receiver The address of the receiver for the yield stream.
+     * @param shares The number of shares returned to the streamer upon closing the yield stream.
+     * @param principal The principal amount in asset units, ie the value of the shares at the time of closing the stream.
+     */
     event Close(
         uint256 indexed streamId, address indexed streamer, address indexed receiver, uint256 shares, uint256 principal
     );
 
-    /// @dev underlying ERC4646 vault
+    /// @notice the underlying ERC4626 vault
     IERC4626 public immutable vault;
 
-    /// @dev identifier for the next new stream (ERC721 token ID)
+    /// @notice the underlying ERC20 asset of the ERC4626 vault
+    IERC20 public immutable asset;
+
+    /// @notice identifier of the next stream to be opened (ERC721 token ID)
     uint256 public nextStreamId = 1;
 
-    /// @dev receiver addresses to the number of shares they are entitled to as yield beneficiaries
-    mapping(address => uint256) public receiverShares;
+    /// @notice receiver addresses to the total shares amount allocated to their streams
+    mapping(address => uint256) public receiverTotalShares;
 
-    /// @dev receiver addresses to the total principal amount allocated, ie not claimable as yield
+    /// @notice receiver addresses to the total principal amount allocated to their streams
     mapping(address => uint256) public receiverTotalPrincipal;
 
-    /// @dev receiver addresses to streamId to principal amount allocated
+    /// @notice receiver addresses to the principal amount allocated to each stream (receiver => (streamId => principal))
     mapping(address => mapping(uint256 => uint256)) public receiverPrincipal;
 
-    /// @dev token id to receiver
+    /// @notice stream ID to receiver address
     mapping(uint256 => address) public streamIdToReceiver;
 
+    /**
+     * @notice Creates a new YieldStreaming contract, initializing the ERC721 token with custom names and setting the vault address.
+     * @dev The constructor initializes an ERC721 token with a dynamic name and symbol derived from the underlying vault's characteristics.
+     * @param _vault Address of the ERC4626 vault
+     */
     constructor(IERC4626 _vault)
         ERC721(string.concat("Yield Streaming - ", _vault.name()), string.concat("YST-", _vault.symbol()))
     {
         _checkZeroAddress(address(_vault));
 
         vault = _vault;
+        asset = IERC20(_vault.asset());
     }
 
     /**
      * @notice Opens a new yield stream between the caller (streamer) and a receiver, represented by an ERC721 token.
+     * The streamer allocates a specified number of ERC4626 shares to the stream, which are used to generate yield for the receiver.
+     * Yield is defined as the difference between the current value of the shares in asset units and the value of the shares at the time of opening the stream (principal).
      * @dev When a new stream is opened, an ERC721 token is minted to the streamer, uniquely identifying the stream.
-     * This token represents the ownership of the yield stream and can be held, transferred, or utilized in other contracts.
+     * This token represents the ownership of the yield stream (and principal allocated to it) and can be held, transferred, or utilized in other contracts.
      * The function calculates the principal amount based on the shares provided, updating the total principal allocated to the receiver.
      * If the receiver is in debt (where the total value of their streams is less than the allocated principal),
      * the function assesses if the new shares would incur an immediate loss exceeding the streamer's specified tolerance.
      *
      * @param _receiver The address of the receiver for the yield stream.
-     * @param _shares The number of shares to allocate to the new yield stream. Shares represent a portion of the underlying ERC4626 vault tokens.
+     * @param _shares The number of shares to allocate to the new yield stream.
      * @param _maxLossOnOpenTolerancePercent The maximum percentage of loss on the principal that the streamer is willing to tolerate upon opening the stream.
      * This parameter is crucial if the receiver is in debt, affecting the feasibility of opening the stream.
      * @return streamId The unique identifier for the newly opened yield stream, represented by an ERC721 token.
-     * This token encapsulates the stream's details and ownership, enabling further interactions and management.
      */
     function open(address _receiver, uint256 _shares, uint256 _maxLossOnOpenTolerancePercent)
         public
         returns (uint256 streamId)
     {
-        uint256 principal = previewOpen(_receiver, _shares, _maxLossOnOpenTolerancePercent);
+        // uint256 principal = previewOpen(_receiver, _shares, _maxLossOnOpenTolerancePercent);
+        uint256 principal = _convertToAssets(_shares);
 
-        streamId = nextStreamId++;
+        _canOpen(_receiver, _shares, principal, _maxLossOnOpenTolerancePercent);
 
-        _mint(msg.sender, streamId);
-        streamIdToReceiver[streamId] = _receiver;
-
-        receiverShares[_receiver] += _shares;
-        receiverTotalPrincipal[_receiver] += principal;
-        receiverPrincipal[_receiver][streamId] += principal;
-
-        emit Open(streamId, msg.sender, _receiver, _shares, principal);
+        streamId = _openStream(_receiver, _shares, principal);
 
         vault.safeTransferFrom(msg.sender, address(this), _shares);
     }
 
     /**
-     * @notice Provides a preview of the principal amount for opening yield stream and reverts if the operation would fail.
+     * @notice Provides a preview of the shares that would be allocated upon opening a new yield stream and reverts if the operation would fail.
+     *
      * @param _receiver The address of the receiver.
-     * @param _shares The number of shares involved in the operation.
+     * @param _shares The number of shares to allocate to the new yield stream.
      * @param _maxLossOnOpenTolerancePercent The maximum loss percentage tolerated by the sender.
-     * @return principal The principal amount in asset units that would be allocated for the shares.
+     * @return principal The principal amount in asset units (ie shares value at open)
      */
     function previewOpen(address _receiver, uint256 _shares, uint256 _maxLossOnOpenTolerancePercent)
         public
         view
         returns (uint256 principal)
     {
-        _checkZeroAddress(_receiver);
-        _checkZeroAmount(_shares);
-
         principal = _convertToAssets(_shares);
 
-        _checkImmediateLossOnOpen(_receiver, principal, _maxLossOnOpenTolerancePercent);
+        _canOpen(_receiver, _shares, principal, _maxLossOnOpenTolerancePercent);
     }
 
     /**
-     * @notice Opens a new yield stream with ERC4626 vault shares for a specified receiver using ERC20 permit for token allowance.
-     * @dev This function allows the opening of a new yield stream without requiring a separate transaction for token allowance, using the ERC20 permit function.
-     * It enables a seamless user experience by allowing token approval and yield stream creation in a single transaction.
+     * @notice Opens a new yield stream with ERC4626 vault shares for a specified receiver using ERC4626 permit for setting the allowance.
+     * @dev This function allows opening of a new yield stream without requiring a separate approval transaction, by utilizing the "permit" functionality.
+     * It enables a seamless user experience by allowing approval and stream creation in a single transaction.
      * The function mints a new ERC721 token to represent the yield stream, assigning ownership to the streamer.
      *
      * @param _receiver The address of the receiver for the yield stream.
@@ -149,10 +194,90 @@ contract YieldStreaming is ERC721, Multicall {
     }
 
     /**
+     * @notice Opens a new yield stream between the caller (streamer) and a receiver, represented by an ERC721 token.
+     * The streamer allocates a specified number of the vault's underlying ERC20 asset to the stream, representing the principal amount.
+     * This amount is then deposited to the ERC4626 vault to obtan the corresponding shares, which are used to generate yield for the receiver.
+     * Yield is defined as the difference between the current value of the shares in asset units and the value of the shares at the time of opening the stream (principal).
+     * @dev When a new stream is opened, an ERC721 token is minted to the streamer, uniquely identifying the stream.
+     * This token represents the ownership of the yield stream (and principal allocated to it) and can be held, transferred, or utilized in other contracts.
+     * The function calculates the principal amount based on the shares provided, updating the total principal allocated to the receiver.
+     * If the receiver is in debt (where the total value of their streams is less than the allocated principal),
+     * the function assesses if the new shares would incur an immediate loss exceeding the streamer's specified tolerance.
+     *
+     * @param _receiver The address of the receiver for the yield stream.
+     * @param _principal The amount in asset units to be allocated to the new yield stream as shares (ie principal amount).
+     * @param _maxLossOnOpenTolerancePercent The maximum percentage of loss on the principal that the streamer is willing to tolerate upon opening the stream.
+     * This parameter is crucial if the receiver is in debt, affecting the feasibility of opening the stream.
+     * @return streamId The unique identifier for the newly opened yield stream, represented by an ERC721 token.
+     * This token encapsulates the stream's details and ownership, enabling further interactions and management.
+     */
+    function openWithAssets(address _receiver, uint256 _principal, uint256 _maxLossOnOpenTolerancePercent)
+        public
+        returns (uint256 streamId)
+    {
+        asset.safeTransferFrom(msg.sender, address(this), _principal);
+
+        asset.forceApprove(address(vault), _principal);
+
+        uint256 shares = vault.deposit(_principal, address(this));
+
+        _canOpen(_receiver, shares, _principal, _maxLossOnOpenTolerancePercent);
+
+        streamId = _openStream(_receiver, shares, _principal);
+    }
+
+    /**
+     * @notice Provides a preview of the shares that would be allocated upon opening a new yield stream with the specified principal amount,
+     * and reverts if the operation would fail.
+     *
+     * @param _receiver The address of the receiver for the yield stream.
+     * @param _principal The principal amount in asset units to be allocated to the new yield stream.
+     * @param _maxLossOnOpenTolerancePercent The maximum percentage of loss on the principal that the streamer is willing to tolerate upon opening the stream.
+     * @return shares The estimated number of shares that would be allocated to the receiver upon opening the yield stream.
+     */
+    function previewOpenWithAssets(address _receiver, uint256 _principal, uint256 _maxLossOnOpenTolerancePercent)
+        public
+        view
+        returns (uint256 shares)
+    {
+        shares = _convertToShares(_principal);
+
+        _canOpen(_receiver, shares, _principal, _maxLossOnOpenTolerancePercent);
+    }
+
+    /**
+     * @notice Opens a new yield stream with ERC4626 vault's underlying ERC20 asset for a specified receiver using ERC20 permit for setting the allowance.
+     * @dev This function allows opening of a new yield stream without requiring a separate approval transaction, by utilizing the "permit" functionality.
+     * It enables a seamless user experience by allowing approval and stream creation in a single transaction.
+     * The function mints a new ERC721 token to represent the yield stream, assigning ownership to the streamer.
+     *
+     * @param _receiver The address of the receiver for the yield stream.
+     * @param _principal The amount in asset units to be allocated to the new yield stream as shares (ie principal amount).
+     * @param _maxLossOnOpenTolerancePercent The maximum loss percentage tolerated by the sender.
+     * @param deadline The timestamp by which the permit must be used, ensuring the permit does not remain valid indefinitely.
+     * @param v The recovery byte of the signature, a part of the permit approval process.
+     * @param r The first 32 bytes of the signature, another component of the permit.
+     * @param s The second 32 bytes of the signature, completing the permit approval requirements.
+     * @return streamId The unique identifier for the newly opened yield stream, represented by an ERC721 token.
+     * This token encapsulates the stream's details and ownership, enabling further interactions and management.
+     */
+    function openWithAssetsUsingPermit(
+        address _receiver,
+        uint256 _principal,
+        uint256 _maxLossOnOpenTolerancePercent,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 streamId) {
+        IERC2612(vault.asset()).permit(msg.sender, address(this), _principal, deadline, v, r, s);
+
+        streamId = openWithAssets(_receiver, _principal, _maxLossOnOpenTolerancePercent);
+    }
+
+    /**
      * @notice Adds additional shares to an existing yield stream, increasing the principal allocated to the receiver.
-     * @dev This function allows a streamer to add more shares to a yield stream represented by a specific ERC721 token.
-     * The additional shares increase the principal amount allocated to the receiver, potentially altering the yield generation rate of the stream.
-     * The function requires that the caller is the owner of the ERC721 token associated with the yield stream.
+     * @dev The function requires that the caller is the owner of the ERC721 token associated with the yield stream.
      *
      * @param _streamId The unique identifier of the yield stream (ERC721 token) to be topped up.
      * @param _shares The number of additional shares to be added to the yield stream.
@@ -162,23 +287,16 @@ contract YieldStreaming is ERC721, Multicall {
         _checkZeroAmount(_shares);
         _checkIsOwner(_streamId);
 
-        address _receiver = streamIdToReceiver[_streamId];
-
         principal = _convertToAssets(_shares);
 
-        receiverShares[_receiver] += _shares;
-        receiverTotalPrincipal[_receiver] += principal;
-        receiverPrincipal[_receiver][_streamId] += principal;
-
-        emit TopUp(_streamId, msg.sender, _receiver, _shares, principal);
+        _topUpStream(_streamId, _shares, principal);
 
         vault.safeTransferFrom(msg.sender, address(this), _shares);
     }
 
     /**
      * @notice Adds additional shares to an existing yield stream, increasing the principal allocated to the receiver using ERC20 permit for token allowance.
-     * @dev This function allows the streamer to add more shares to an existing yield stream without requiring a separate transaction for token allowance.
-     * It uses the ERC20 permit function to approve the token transfer and top-up the yield stream in a single transaction.
+     * @dev It uses the ERC20 permit function to approve the token transfer and top-up the yield stream in a single transaction.
      * The function requires that the caller is the owner of the ERC721 token associated with the yield stream.
      *
      * @param _streamId The unique identifier of the yield stream (ERC721 token) to be topped up.
@@ -196,6 +314,53 @@ contract YieldStreaming is ERC721, Multicall {
         IERC2612(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
 
         principal = topUp(_streamId, _shares);
+    }
+
+    /**
+     * @notice Adds additional principal to an existing yield stream, increasing the principal allocated to the receiver.
+     * @dev The function requires that the caller is the owner of the ERC721 token associated with the yield stream.
+     *
+     * @param _streamId The unique identifier of the yield stream (ERC721 token) to be topped up.
+     * @param _principal The additional principal amount in asset units to be added to the yield stream.
+     * @return shares The added number of shares to the yield stream.
+     */
+    function topUpWithAssets(uint256 _streamId, uint256 _principal) public returns (uint256 shares) {
+        _checkZeroAmount(_principal);
+        _checkIsOwner(_streamId);
+
+        asset.safeTransferFrom(msg.sender, address(this), _principal);
+
+        asset.forceApprove(address(vault), _principal);
+
+        shares = vault.deposit(_principal, address(this));
+
+        _topUpStream(_streamId, shares, _principal);
+    }
+
+    /**
+     * @notice Adds additional principal to an existing yield stream, increasing the principal allocated to the receiver using ERC20 permit for token allowance.
+     * @dev It uses the ERC20 permit function to approve the token transfer and top-up the yield stream in a single transaction.
+     * The function requires that the caller is the owner of the ERC721 token associated with the yield stream.
+     *
+     * @param _streamId The unique identifier of the yield stream (ERC721 token) to be topped up.
+     * @param _principal The additional principal amount in asset units to be added to the yield stream.
+     * @param deadline The timestamp by which the permit must be used, ensuring the permit does not remain valid indefinitely.
+     * @param v The recovery byte of the signature, a part of the permit approval process.
+     * @param r The first 32 bytes of the signature, another component of the permit.
+     * @param s The second 32 bytes of the signature, completing the permit approval requirements.
+     * @return shares The added number of shares to the yield stream.
+     */
+    function topUpWithAssetsUsingPermit(
+        uint256 _streamId,
+        uint256 _principal,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 shares) {
+        IERC2612(address(vault.asset())).permit(msg.sender, address(this), _principal, deadline, v, r, s);
+
+        shares = topUpWithAssets(_streamId, _principal);
     }
 
     /**
@@ -223,7 +388,7 @@ contract YieldStreaming is ERC721, Multicall {
         delete streamIdToReceiver[_streamId];
         delete receiverPrincipal[receiver][_streamId];
         receiverTotalPrincipal[receiver] -= principal;
-        receiverShares[receiver] -= shares;
+        receiverTotalShares[receiver] -= shares;
 
         emit Close(_streamId, msg.sender, receiver, shares, principal);
 
@@ -255,7 +420,7 @@ contract YieldStreaming is ERC721, Multicall {
         uint256 totalPrincipal = receiverTotalPrincipal[_receiver];
 
         // calculate the maximum amount of shares that can be attributed to the sender as a percentage of the sender's share of the total principal.
-        uint256 have = receiverShares[_receiver].mulDivDown(principal, totalPrincipal);
+        uint256 have = receiverTotalShares[_receiver].mulDivDown(principal, totalPrincipal);
 
         // true if there was a loss (negative yield)
         shares = ask > have ? have : ask;
@@ -278,7 +443,7 @@ contract YieldStreaming is ERC721, Multicall {
 
         if (yieldInShares == 0) revert NoYieldToClaim();
 
-        receiverShares[msg.sender] -= yieldInShares;
+        receiverTotalShares[msg.sender] -= yieldInShares;
 
         assets = vault.redeem(yieldInShares, _sendTo, address(this));
 
@@ -295,7 +460,7 @@ contract YieldStreaming is ERC721, Multicall {
      */
     function previewClaimYield(address _receiver) public view returns (uint256 yield) {
         uint256 principal = receiverTotalPrincipal[_receiver];
-        uint256 currentValue = _convertToAssets(receiverShares[_receiver]);
+        uint256 currentValue = _convertToAssets(receiverTotalShares[_receiver]);
 
         // if vault made a loss, there is no yield
         yield = currentValue > principal ? currentValue - principal : 0;
@@ -320,7 +485,7 @@ contract YieldStreaming is ERC721, Multicall {
 
         if (shares == 0) revert NoYieldToClaim();
 
-        receiverShares[msg.sender] -= shares;
+        receiverTotalShares[msg.sender] -= shares;
 
         emit ClaimYieldInShares(msg.sender, _sendTo, shares);
 
@@ -337,7 +502,7 @@ contract YieldStreaming is ERC721, Multicall {
      */
     function previewClaimYieldInShares(address _receiver) public view returns (uint256 yieldInShares) {
         uint256 principalInShares = _convertToShares(receiverTotalPrincipal[_receiver]);
-        uint256 shares = receiverShares[_receiver];
+        uint256 shares = receiverTotalShares[_receiver];
 
         // if vault made a loss, there is no yield
         yieldInShares = shares > principalInShares ? shares - principalInShares : 0;
@@ -355,7 +520,7 @@ contract YieldStreaming is ERC721, Multicall {
      */
     function debtFor(address _receiver) public view returns (uint256) {
         uint256 principal = receiverTotalPrincipal[_receiver];
-        uint256 currentValue = _convertToAssets(receiverShares[_receiver]);
+        uint256 currentValue = _convertToAssets(receiverTotalShares[_receiver]);
 
         return currentValue < principal ? principal - currentValue : 0;
     }
@@ -381,12 +546,42 @@ contract YieldStreaming is ERC721, Multicall {
         return receiverPrincipal[_receiver][_streamId];
     }
 
-    function _checkImmediateLossOnOpen(address _receiver, uint256 _principal, uint256 _lossTolerancePercent)
+    // accounting logic for opening a new stream
+    function _openStream(address _receiver, uint256 _shares, uint256 _principal) internal returns (uint256 streamId) {
+        streamId = nextStreamId++;
+
+        _mint(msg.sender, streamId);
+        streamIdToReceiver[streamId] = _receiver;
+
+        receiverTotalShares[_receiver] += _shares;
+        receiverTotalPrincipal[_receiver] += _principal;
+        receiverPrincipal[_receiver][streamId] = _principal;
+
+        emit Open(streamId, msg.sender, _receiver, _shares, _principal);
+    }
+
+    // accounting logic for topping up a stream
+    function _topUpStream(uint256 _streamId, uint256 _shares, uint256 _principal) internal {
+        address _receiver = streamIdToReceiver[_streamId];
+
+        receiverTotalShares[_receiver] += _shares;
+        receiverTotalPrincipal[_receiver] += _principal;
+        receiverPrincipal[_receiver][_streamId] += _principal;
+
+        emit TopUp(_streamId, msg.sender, _receiver, _shares, _principal);
+    }
+
+    function _canOpen(address _receiver, uint256 _shares, uint256 _principal, uint256 _maxLossOnOpenTolerancePercent)
         internal
         view
     {
+        _checkZeroAddress(_receiver);
+        _checkZeroAmount(_principal);
+
         // when opening a new stream from sender, check if the receiver is in debt
-        uint256 debt = debtFor(_receiver);
+        uint256 sharePrice = _principal.divWadUp(_shares);
+        uint256 totalPrincipal = receiverTotalPrincipal[_receiver];
+        uint256 debt = _calculateDebt(totalPrincipal, receiverTotalShares[_receiver], sharePrice);
 
         if (debt == 0) return;
 
@@ -394,9 +589,21 @@ contract YieldStreaming is ERC721, Multicall {
         // the immediate loss is calculated as the percentage of the debt that the sender is taking as his share of the total principal allocated to the receiver.
         // acceptable loss is defined by the loss tolerance percentage param passed to the open function.
         // this loss occurs due to inability of the accounting logic to differentiate between principal amounts allocated from different streams to same receiver.
-        uint256 lossOnOpen = debt.mulDivUp(_principal, receiverTotalPrincipal[_receiver] + _principal);
+        totalPrincipal = totalPrincipal + _principal;
+        uint256 lossOnOpen = debt.mulDivUp(_principal, totalPrincipal);
+        uint256 maxLoss = _principal.mulWadUp(_maxLossOnOpenTolerancePercent);
 
-        if (lossOnOpen > _principal.mulWadUp(_lossTolerancePercent)) revert LossToleranceExceeded();
+        if (lossOnOpen > maxLoss) revert LossToleranceExceeded();
+    }
+
+    function _calculateDebt(uint256 _totalPrincipal, uint256 _totalShares, uint256 _sharePrice)
+        internal
+        pure
+        returns (uint256 debt)
+    {
+        uint256 currentValue = _totalShares.mulWadUp(_sharePrice);
+
+        debt = currentValue < _totalPrincipal ? _totalPrincipal - currentValue : 0;
     }
 
     function _checkZeroAddress(address _address) internal pure {

--- a/test/YieldStreaming.t.sol
+++ b/test/YieldStreaming.t.sol
@@ -64,13 +64,15 @@ contract YieldStreamingTest is TestCommon {
 
         // nft ids start from 1
         assertEq(yieldStreaming.nextStreamId(), 1, "next stream id");
+        assertEq(address(yieldStreaming.asset()), address(asset), "underlying asset");
+        // vault is not allowed to transfer assets by default
+        assertEq(asset.allowance(address(yieldStreaming), address(vault)), 0, "allowance");
     }
 
     /// *** #open *** ///
 
     function test_open_failsFor0Shares() public {
-        uint256 shares = _depositToVault(alice, 1e18);
-        _approveYieldStreaming(alice, shares);
+        _depositToVaultAndApprove(alice, 1e18);
 
         vm.startPrank(alice);
         vm.expectRevert(AmountZero.selector);
@@ -78,8 +80,7 @@ contract YieldStreamingTest is TestCommon {
     }
 
     function test_open_failsIfReceiverIsAddress0() public {
-        uint256 shares = _depositToVault(alice, 1e18);
-        _approveYieldStreaming(alice, shares);
+        uint256 shares = _depositToVaultAndApprove(alice, 1e18);
 
         vm.startPrank(alice);
         vm.expectRevert(AddressZero.selector);
@@ -88,8 +89,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_open_mintsNtfAndTransfersShares() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
+        uint256 shares = _depositToVaultAndApprove(alice, principal);
 
         vm.startPrank(alice);
         uint256 streamId = yieldStreaming.open(bob, shares, 0);
@@ -100,15 +100,14 @@ contract YieldStreamingTest is TestCommon {
         assertEq(yieldStreaming.balanceOf(alice), 1, "nft balance of alice");
 
         assertEq(vault.balanceOf(address(yieldStreaming)), shares, "contract's shares");
-        assertEq(yieldStreaming.receiverShares(bob), shares, "receiver shares");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares, "receiver shares");
         assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "receiver total principal");
         assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal, "receiver principal");
     }
 
     function test_open_emitsEvent() public {
         uint256 principal = 4e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
+        uint256 shares = _depositToVaultAndApprove(alice, principal);
 
         uint256 streamId = yieldStreaming.nextStreamId();
 
@@ -121,8 +120,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_open_toTwoReceivers() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, 1e18);
-        _approveYieldStreaming(alice, shares);
+        uint256 shares = _depositToVaultAndApprove(alice, principal);
 
         vm.startPrank(alice);
         uint256 firstId = yieldStreaming.open(bob, shares / 2, 0);
@@ -134,19 +132,18 @@ contract YieldStreamingTest is TestCommon {
 
         assertEq(vault.balanceOf(alice), shares / 4, "alice's shares");
 
-        assertEq(yieldStreaming.receiverShares(bob), shares / 2, "receiver shares bob");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares / 2, "receiver shares bob");
         assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal / 2, "principal bob");
         assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal / 2, "receiver principal  bob");
 
-        assertEq(yieldStreaming.receiverShares(carol), shares / 4, "receiver shares carol");
+        assertEq(yieldStreaming.receiverTotalShares(carol), shares / 4, "receiver shares carol");
         assertEq(yieldStreaming.receiverTotalPrincipal(carol), principal / 4, "principal carol");
         assertEq(yieldStreaming.receiverPrincipal(carol, 2), principal / 4, "receiver principal  carol");
     }
 
     function test_open_failsIfReceiverIsInDebtAndImmediateLossIsAboveLossTolerancePercent() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
+        uint256 alicesShares = _depositToVaultAndApprove(alice, alicesPrincipal);
 
         // alice opens a stream to carol
         vm.prank(alice);
@@ -176,8 +173,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_open_worksIfReceiverIsInDebtAndLossIsBelowLossTolerancePercent() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
+        uint256 alicesShares = _depositToVaultAndApprove(alice, alicesPrincipal);
 
         // alice opens a stream to carol
         vm.prank(alice);
@@ -246,7 +242,185 @@ contract YieldStreamingTest is TestCommon {
 
         assertEq(streamId, 1, "stream id");
         assertEq(vault.balanceOf(address(yieldStreaming)), shares, "contract's shares");
-        assertEq(yieldStreaming.receiverShares(bob), shares, "receiver shares");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares, "receiver shares");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "receiver total principal");
+        assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal, "receiver principal");
+    }
+
+    /// *** #openWithAssets *** ///
+
+    function test_openWithAssets_failsFor0Assets() public {
+        _approveAssetsAndPreviewDeposit(alice, 1e18);
+
+        // fails to deposit 0 amount to the vault
+        vm.expectRevert("ZERO_SHARES");
+        vm.prank(alice);
+        yieldStreaming.openWithAssets(bob, 0, 0);
+    }
+
+    function test_openWithAssets_failsIfReceiverIsAddress0() public {
+        uint256 principal = 1e18;
+        _approveAssetsAndPreviewDeposit(alice, principal);
+
+        // underflows when trying to transfer assets from address(0)
+        vm.expectRevert();
+        yieldStreaming.openWithAssets(address(0), principal, 0);
+    }
+
+    function test_openWithAssets_mintsNtfAndTransfersShares() public {
+        uint256 principal = 1e18;
+        _approveAssetsAndPreviewDeposit(alice, principal);
+
+        uint256 shares = yieldStreaming.previewOpenWithAssets(bob, principal, 0);
+        assertEq(shares, vault.convertToShares(principal), "preview open with assets");
+
+        vm.prank(alice);
+        uint256 streamId = yieldStreaming.openWithAssets(bob, principal, 0);
+
+        assertEq(streamId, 1, "stream id");
+        assertEq(yieldStreaming.nextStreamId(), 2, "next stream id");
+        assertEq(yieldStreaming.ownerOf(streamId), alice, "owner of token");
+        assertEq(yieldStreaming.balanceOf(alice), 1, "nft balance of alice");
+
+        assertEq(vault.balanceOf(address(yieldStreaming)), shares, "contract's shares");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares, "receiver shares");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "receiver total principal");
+        assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal, "receiver principal");
+    }
+
+    function test_openWithAssets_emitsEvent() public {
+        uint256 principal = 1e18;
+        uint256 shares = _approveAssetsAndPreviewDeposit(alice, principal);
+        uint256 streamId = yieldStreaming.nextStreamId();
+
+        vm.expectEmit(true, true, true, true);
+        emit Open(streamId, alice, bob, shares, principal);
+
+        vm.prank(alice);
+        yieldStreaming.openWithAssets(bob, principal, 0);
+    }
+
+    function test_openWithAssets_toTwoReceivers() public {
+        uint256 principal = 1e18;
+        _approveAssetsAndPreviewDeposit(alice, principal);
+
+        vm.startPrank(alice);
+        uint256 firstId = yieldStreaming.openWithAssets(bob, principal / 2, 0);
+        uint256 secondId = yieldStreaming.openWithAssets(carol, principal / 4, 0);
+
+        assertEq(firstId, 1, "first id");
+        assertEq(secondId, 2, "second id");
+        assertEq(yieldStreaming.nextStreamId(), 3, "next stream id");
+
+        assertEq(asset.balanceOf(alice), principal / 4, "alice's assets");
+
+        assertEq(yieldStreaming.receiverTotalShares(bob), vault.convertToShares(principal / 2), "receiver shares bob");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal / 2, "principal bob");
+        assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal / 2, "receiver principal  bob");
+
+        assertEq(
+            yieldStreaming.receiverTotalShares(carol), vault.convertToShares(principal / 4), "receiver shares carol"
+        );
+        assertEq(yieldStreaming.receiverTotalPrincipal(carol), principal / 4, "principal carol");
+        assertEq(yieldStreaming.receiverPrincipal(carol, 2), principal / 4, "receiver principal  carol");
+    }
+
+    function test_openWithAssets_failsIfReceiverIsInDebtAndImmediateLossIsAboveLossTolerancePercent() public {
+        uint256 principal = 1e18;
+        _approveAssetsAndPreviewDeposit(alice, principal);
+
+        // alice opens a stream to carol
+        vm.prank(alice);
+        yieldStreaming.openWithAssets(carol, principal, 0);
+
+        // create 10% loss
+        _generateYield(-0.1e18);
+        assertEq(yieldStreaming.debtFor(carol), 0.1e18, "debt for carol");
+
+        uint256 bobsPrincipal = 2e18;
+        uint256 bobsShares = _depositToVault(bob, bobsPrincipal);
+        _approveYieldStreaming(bob, bobsShares);
+
+        // debt for carol = 0.1e18
+        // alice's principal = 1e18
+        // bob's principal = 2e18
+        // bob's share of loss = 0.1e18 * 2e18 / (1e18 + 2e18) = 0.066e18
+        // bob's loss on open = 2e18 - 0.066e18 = 1.933e18
+        // bbo's loss in pct = 1 - 1.933e18 / 2e18 = 1 - 0.9665 = 0.0335 = 3.35%
+
+        // bob opens a stream to carol
+        uint256 toleratedLossOnOpenPct = 0.033e18; // 3.3%
+        vm.prank(bob);
+        vm.expectRevert(YieldStreaming.LossToleranceExceeded.selector);
+        yieldStreaming.open(carol, bobsShares, toleratedLossOnOpenPct);
+    }
+
+    function test_openWithAssets_worksIfReceiverIsInDebtAndLossIsBelowLossTolerancePercent() public {
+        _openYieldStream(alice, carol, 1e18);
+
+        // create 10% loss
+        _generateYield(-0.1e18);
+        assertEq(yieldStreaming.debtFor(carol), 0.1e18, "debt for carol");
+
+        uint256 bobsPrincipal = 2e18;
+        _approveAssetsAndPreviewDeposit(bob, bobsPrincipal);
+
+        // debt for carol = 0.1e18
+        // alice's principal = 1e18
+        // bob's principal = 2e18
+        // bob's share of loss = 0.1e18 * 2e18 / (1e18 + 2e18) = 0.066e18
+        // bob's loss on open = 2e18 - 0.066e18 = 1.933e18
+        // bbo's loss in pct = 1 - 1.933e18 / 2e18 = 1 - 0.9665 = 0.0335 = 3.35%
+
+        // bob opens a stream to carol
+        uint256 toleratedLossOnOpenPct = 0.034e18; // 3.4%
+        vm.prank(bob);
+        uint256 streamId = yieldStreaming.openWithAssets(carol, bobsPrincipal, toleratedLossOnOpenPct);
+
+        uint256 principalWithLoss = vault.convertToAssets(yieldStreaming.previewClose(2));
+        uint256 bobsLossOnOpen = bobsPrincipal - principalWithLoss;
+
+        assertTrue(principalWithLoss < bobsPrincipal, "principal with loss > bobs deposit");
+        assertApproxEqRel(principalWithLoss, bobsPrincipal, toleratedLossOnOpenPct, "principal with loss");
+        assertTrue(bobsLossOnOpen < bobsPrincipal.mulWadDown(toleratedLossOnOpenPct), "loss tolerance exceeded");
+
+        vm.prank(bob);
+        yieldStreaming.close(streamId);
+
+        uint256 bobsPrincipalAfterClose = vault.convertToAssets(vault.balanceOf(bob));
+        assertApproxEqAbs(bobsPrincipalAfterClose, bobsPrincipal - bobsLossOnOpen, 1, "bobs principal after close");
+    }
+
+    function test_openWithAssetsUsingPermit() public {
+        uint256 davesPrivateKey = uint256(bytes32("0xDAVE"));
+        address dave = vm.addr(davesPrivateKey);
+
+        uint256 principal = 1 ether;
+        uint256 nonce = asset.nonces(dave);
+        uint256 deadline = block.timestamp + 1 days;
+        deal(address(asset), dave, principal);
+
+        bytes32 PERMIT_TYPEHASH =
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+        // Sign the permit message
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            davesPrivateKey,
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    MockERC20(asset).DOMAIN_SEPARATOR(),
+                    keccak256(abi.encode(PERMIT_TYPEHASH, dave, address(yieldStreaming), principal, nonce, deadline))
+                )
+            )
+        );
+
+        vm.prank(dave);
+        uint256 streamId = yieldStreaming.openWithAssetsUsingPermit(bob, principal, 0, deadline, v, r, s);
+
+        assertEq(streamId, 1, "stream id");
+        assertEq(vault.balanceOf(address(yieldStreaming)), vault.convertToShares(principal), "contract's shares");
+        assertEq(yieldStreaming.receiverTotalShares(bob), vault.convertToShares(principal), "receiver shares");
         assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "receiver total principal");
         assertEq(yieldStreaming.receiverPrincipal(bob, 1), principal, "receiver principal");
     }
@@ -255,6 +429,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_topUp_failsIfAmountIs0() public {
         uint256 streamId = _openYieldStream(alice, bob, 1e18);
+        _depositToVaultAndApprove(alice, 1e18);
 
         vm.prank(alice);
         vm.expectRevert(AmountZero.selector);
@@ -263,9 +438,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_topUp_failsIfStreamDoesntExist() public {
         uint256 streamId = _openYieldStream(alice, bob, 1e18);
-        uint256 shares = _depositToVault(alice, 1e18);
-        _approveYieldStreaming(alice, shares);
-
+        uint256 shares = _depositToVaultAndApprove(alice, 1e18);
         uint256 invalidTokenId = streamId + 1;
 
         vm.prank(alice);
@@ -275,9 +448,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_topUp_failsIfCallerIsNotOwner() public {
         uint256 streamId = _openYieldStream(alice, bob, 1e18);
-
-        uint256 shares = _depositToVault(carol, 1e18);
-        _approveYieldStreaming(carol, shares);
+        uint256 shares = _depositToVaultAndApprove(alice, 1e18);
 
         vm.prank(carol);
         vm.expectRevert(YieldStreaming.CallerNotOwner.selector);
@@ -286,44 +457,39 @@ contract YieldStreamingTest is TestCommon {
 
     function test_topUp_addsToExistingStream() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        uint256 addedPrincipal = 2e18;
+        uint256 addedShares = _depositToVaultAndApprove(alice, addedPrincipal);
 
         vm.startPrank(alice);
-        uint256 streamId = yieldStreaming.open(bob, shares / 2, 0);
-
-        assertEq(yieldStreaming.receiverShares(bob), shares / 2, "receiver shares bob");
-        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal / 2, "principal bob");
-        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal / 2, "receiver principal  bob");
 
         // top up stream
-        yieldStreaming.topUp(streamId, shares / 2);
+        yieldStreaming.topUp(streamId, addedShares);
 
-        assertEq(yieldStreaming.receiverShares(bob), shares, "receiver shares bob");
-        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "principal bob");
-        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal, "receiver principal  bob");
+        uint256 expectedPrincipal = principal + addedPrincipal;
+        assertEq(
+            yieldStreaming.receiverTotalShares(bob), vault.convertToShares(expectedPrincipal), "receiver shares bob"
+        );
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), expectedPrincipal, "principal bob");
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), expectedPrincipal, "receiver principal  bob");
     }
 
     function test_topUp_emitsEvent() public {
-        uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
 
-        vm.startPrank(alice);
-        uint256 streamId = yieldStreaming.open(bob, shares / 2, 0);
+        uint256 addedPrincipal = 2e18;
+        uint256 addedShares = _depositToVaultAndApprove(alice, addedPrincipal);
 
         vm.expectEmit(true, true, true, true);
-        emit TopUp(streamId, alice, bob, shares / 2, principal / 2);
+        emit TopUp(streamId, alice, bob, addedShares, addedPrincipal);
 
-        yieldStreaming.topUp(streamId, shares / 2);
+        vm.prank(alice);
+        yieldStreaming.topUp(streamId, addedShares);
     }
 
     function test_topUp_doesntAffectYieldAccrued() public {
-        uint256 shares = _depositToVault(alice, 2e18);
-        _approveYieldStreaming(alice, shares);
-
-        vm.startPrank(alice);
-        yieldStreaming.open(bob, shares / 2, 0);
+        uint256 streamId = _openYieldStream(alice, bob, 2e18);
 
         _generateYield(0.2e18);
         uint256 yield = yieldStreaming.previewClaimYield(bob);
@@ -332,53 +498,58 @@ contract YieldStreamingTest is TestCommon {
         assertEq(yieldStreaming.previewClaimYield(bob), yield, "yield before top up");
 
         // top up stream
-        yieldStreaming.topUp(1, shares / 2);
+        uint256 addedShares = _depositToVaultAndApprove(alice, 1e18);
+
+        vm.prank(alice);
+        yieldStreaming.topUp(streamId, addedShares);
 
         // yield should remain the same
-        assertEq(yieldStreaming.previewClaimYield(bob), yield, "yield after top up");
+        assertApproxEqAbs(yieldStreaming.previewClaimYield(bob), yield, 1, "yield after top up");
     }
 
     function test_topUp_affectsFutureYield() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
-
-        vm.startPrank(alice);
-        uint256 streamId = yieldStreaming.open(bob, shares / 2, 0);
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
 
         // double the share price
         _generateYield(1e18);
 
-        assertEq(yieldStreaming.previewClaimYield(bob), principal / 2, "yield before top up");
+        assertEq(yieldStreaming.previewClaimYield(bob), principal, "yield before top up");
 
-        // top up stream with the remaining shares
-        yieldStreaming.topUp(streamId, shares / 2);
+        // top up
+        uint256 addedShares = _depositToVaultAndApprove(alice, 2e18);
+
+        vm.prank(alice);
+        yieldStreaming.topUp(streamId, addedShares);
 
         _generateYield(0.5e18);
 
         // share price increased by 200% in total from the initial deposit
         // expected yield is 75% of that whole gain
-        assertEq(yieldStreaming.previewClaimYield(bob), (principal * 2).mulWadUp(0.75e18), "yield after top up");
+        // 1e18 * 2 + 2e18 * 0.5 = 3e18
+        assertEq(yieldStreaming.previewClaimYield(bob), 3e18, "yield after top up");
     }
 
-    function test_topUp_worksWhenReceiverIsInDebtAndLossIsAboveLossTolerancePercent() public {
+    function test_topUp_worksWhenReceiverIsInDebt() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
-        _approveYieldStreaming(alice, shares);
-
-        vm.startPrank(alice);
-        uint256 streamId = yieldStreaming.open(bob, shares / 2, 0);
+        uint256 shares = vault.previewDeposit(principal);
+        uint256 streamId = _openYieldStream(alice, bob, principal);
 
         _generateYield(-0.5e18);
 
-        uint256 claimerDebt = yieldStreaming.debtFor(bob);
+        uint256 receiverDebt = yieldStreaming.debtFor(bob);
 
-        // top up stream with the remaining shares
-        yieldStreaming.topUp(streamId, shares / 2);
+        assertEq(receiverDebt, principal / 2, "receiver debt before top up");
 
-        assertEq(yieldStreaming.debtFor(bob), claimerDebt, "claimer debt");
-        assertEq(yieldStreaming.receiverShares(bob), shares, "receiver shares");
-        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal / 2 + principal / 4, "receiver principal");
+        // top up stream
+        uint256 addedShares = _depositToVaultAndApprove(alice, principal);
+        vm.prank(alice);
+        yieldStreaming.topUp(streamId, addedShares);
+
+        assertEq(yieldStreaming.debtFor(bob), receiverDebt, "receiver debt");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares + addedShares, "receiver shares");
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal * 2, "receiver principal");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal * 2, "receiver total principal");
     }
 
     function test_topUpUsingPermit() public {
@@ -386,12 +557,11 @@ contract YieldStreamingTest is TestCommon {
         address dave = vm.addr(davesPrivateKey);
 
         uint256 principal = 1 ether;
-        uint256 shares = _depositToVault(dave, principal);
+        uint256 streamId = _openYieldStream(dave, bob, principal);
 
-        _approveYieldStreaming(dave, shares / 2);
-
-        vm.prank(dave);
-        uint256 streamId = yieldStreaming.open(bob, shares / 2, 0);
+        // top up
+        uint256 addedPrincipal = 2 ether;
+        uint256 addedShares = _depositToVault(dave, addedPrincipal);
 
         uint256 nonce = vault.nonces(dave);
         uint256 deadline = block.timestamp + 1 days;
@@ -406,18 +576,200 @@ contract YieldStreamingTest is TestCommon {
                 abi.encodePacked(
                     "\x19\x01",
                     MockERC4626(address(vault)).DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, dave, address(yieldStreaming), shares / 2, nonce, deadline))
+                    keccak256(abi.encode(PERMIT_TYPEHASH, dave, address(yieldStreaming), addedShares, nonce, deadline))
                 )
             )
         );
 
         // top up stream
         vm.prank(dave);
-        yieldStreaming.topUpUsingPermit(streamId, shares / 2, deadline, v, r, s);
+        yieldStreaming.topUpUsingPermit(streamId, addedShares, deadline, v, r, s);
 
-        assertEq(yieldStreaming.receiverShares(bob), shares, "receiver shares");
-        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal, "receiver total principal");
-        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal, "receiver principal");
+        assertEq(
+            yieldStreaming.receiverTotalShares(bob), vault.convertToShares(principal) + addedShares, "receiver shares"
+        );
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal + addedPrincipal, "receiver principal");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal + addedPrincipal, "receiver total principal");
+    }
+
+    /// *** #topUpWithAssets *** ///
+
+    function test_topUpWithAssets_failsIfAmountIs0() public {
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+        _approveAssetsAndPreviewDeposit(alice, 1e18);
+
+        vm.prank(alice);
+        vm.expectRevert(AmountZero.selector);
+        yieldStreaming.topUpWithAssets(streamId, 0);
+    }
+
+    function test_topUpWithAssets_failsIfStreamDoesntExist() public {
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        uint256 addedPrincipal = 1e18;
+        _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        uint256 invalidTokenId = streamId + 1;
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, invalidTokenId));
+        yieldStreaming.topUpWithAssets(invalidTokenId, addedPrincipal);
+    }
+
+    function test_topUpWithAssets_failsIfCallerIsNotOwner() public {
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        uint256 addedPrincipal = 1e18;
+        _approveAssetsAndPreviewDeposit(carol, addedPrincipal);
+
+        vm.prank(carol);
+        vm.expectRevert(YieldStreaming.CallerNotOwner.selector);
+        yieldStreaming.topUp(streamId, addedPrincipal);
+    }
+
+    function test_topUpWithAssets_addsToExistingStream() public {
+        uint256 principal = 1e18;
+        uint256 streamId = _openYieldStream(alice, bob, principal);
+
+        uint256 addedPrincipal = 2e18;
+        _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        vm.prank(alice);
+        yieldStreaming.topUpWithAssets(streamId, addedPrincipal);
+
+        uint256 expectedTotalPrincipal = principal + addedPrincipal;
+        assertEq(
+            yieldStreaming.receiverTotalShares(bob),
+            vault.convertToShares(expectedTotalPrincipal),
+            "receiver shares bob"
+        );
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), expectedTotalPrincipal, "principal bob");
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), expectedTotalPrincipal, "receiver principal  bob");
+    }
+
+    function test_topUpWithAssets_emitsEvent() public {
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        uint256 addedPrincipal = 2e18;
+        uint256 addedShares = _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        vm.expectEmit(true, true, true, true);
+        emit TopUp(streamId, alice, bob, addedShares, addedPrincipal);
+
+        vm.prank(alice);
+        yieldStreaming.topUpWithAssets(streamId, addedPrincipal);
+    }
+
+    function test_topUpWithAssets_doesntAffectYieldAccrued() public {
+        uint256 principal = 1e18;
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        _generateYield(0.2e18);
+        uint256 yield = yieldStreaming.previewClaimYield(bob);
+
+        // assert the yield is not 0
+        assertEq(yield, principal.mulWadDown(0.2e18), "yield before top up");
+
+        // top up stream
+        uint256 addedPrincipal = 2e18;
+        _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        vm.prank(alice);
+        yieldStreaming.topUpWithAssets(streamId, addedPrincipal);
+
+        // yield should remain the same
+        assertApproxEqAbs(yieldStreaming.previewClaimYield(bob), yield, 1, "yield after top up");
+    }
+
+    function test_topUpWithAssets_affectsFutureYield() public {
+        uint256 principal = 1e18;
+        uint256 streamId = _openYieldStream(alice, bob, 1e18);
+
+        // double the share price
+        _generateYield(1e18);
+
+        assertEq(yieldStreaming.previewClaimYield(bob), principal, "yield before top up");
+
+        // top up
+        uint256 addedPrincipal = 2e18;
+        _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        vm.prank(alice);
+        yieldStreaming.topUpWithAssets(streamId, addedPrincipal);
+
+        _generateYield(0.5e18);
+
+        // share price increased by 200% in total from the initial deposit
+        // expected yield is 75% of that whole gain
+        // 1e18 * 2 + 2e18 * 0.5 = 3e18
+        assertEq(yieldStreaming.previewClaimYield(bob), 3e18, "yield after top up");
+    }
+
+    function test_topUpWithAssets_worksWhenReceiverIsInDebt() public {
+        uint256 principal = 1e18;
+        uint256 shares = vault.convertToShares(principal);
+        uint256 streamId = _openYieldStream(alice, bob, principal);
+
+        _generateYield(-0.5e18);
+
+        uint256 receiverDebt = yieldStreaming.debtFor(bob);
+
+        assertEq(receiverDebt, principal / 2, "receiver debt before top up");
+
+        // top up
+        uint256 addedPrincipal = 2e18;
+        uint256 addedShares = _approveAssetsAndPreviewDeposit(alice, addedPrincipal);
+
+        vm.prank(alice);
+        yieldStreaming.topUpWithAssets(streamId, addedPrincipal);
+
+        assertEq(yieldStreaming.debtFor(bob), receiverDebt, "receiver debt after top up");
+        assertEq(yieldStreaming.receiverTotalShares(bob), shares + addedShares, "receiver shares");
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), principal + addedPrincipal, "receiver principal");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), principal + addedPrincipal, "receiver total principal");
+    }
+
+    function test_topUpWithAssetsUsingPermit() public {
+        uint256 davesPrivateKey = uint256(bytes32("0xDAVE"));
+        address dave = vm.addr(davesPrivateKey);
+
+        uint256 principal = 1 ether;
+        uint256 streamId = _openYieldStream(dave, bob, principal);
+
+        // top up
+        uint256 addedPrincipal = 2 ether;
+        deal(address(asset), dave, addedPrincipal);
+
+        uint256 nonce = asset.nonces(dave);
+        uint256 deadline = block.timestamp + 1 days;
+
+        bytes32 PERMIT_TYPEHASH =
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+        // Sign the permit message
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            davesPrivateKey,
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    MockERC20(address(asset)).DOMAIN_SEPARATOR(),
+                    keccak256(
+                        abi.encode(PERMIT_TYPEHASH, dave, address(yieldStreaming), addedPrincipal, nonce, deadline)
+                    )
+                )
+            )
+        );
+
+        // top up stream
+        vm.prank(dave);
+        yieldStreaming.topUpWithAssetsUsingPermit(streamId, addedPrincipal, deadline, v, r, s);
+
+        uint256 expectedTotalPrincipal = principal + addedPrincipal;
+        assertEq(
+            yieldStreaming.receiverTotalShares(bob), vault.convertToShares(expectedTotalPrincipal), "receiver shares"
+        );
+        assertEq(yieldStreaming.receiverPrincipal(bob, streamId), expectedTotalPrincipal, "receiver principal");
+        assertEq(yieldStreaming.receiverTotalPrincipal(bob), expectedTotalPrincipal, "receiver total principal");
     }
 
     /// *** #previewClaimYield *** ///
@@ -588,16 +940,10 @@ contract YieldStreamingTest is TestCommon {
 
     function test_claimYield_claimsFromAllOpenedStreams() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
-        uint256 bobsPrincipal = 3e18;
-        uint256 bobsShares = _depositToVault(bob, bobsPrincipal);
-        _approveYieldStreaming(bob, bobsShares);
+        _openYieldStream(alice, carol, alicesPrincipal);
 
-        vm.prank(alice);
-        yieldStreaming.open(carol, alicesShares, 0);
-        vm.prank(bob);
-        yieldStreaming.open(carol, bobsShares, 0);
+        uint256 bobsPrincipal = 3e18;
+        _openYieldStream(bob, carol, bobsPrincipal);
 
         // add 100% profit to vault
         _generateYield(1e18);
@@ -614,16 +960,10 @@ contract YieldStreamingTest is TestCommon {
 
     function test_claimYield_worksIfOneOfStreamsIsClosed() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
-        uint256 bobsPrincipal = 3e18;
-        uint256 bobsShares = _depositToVault(bob, bobsPrincipal);
-        _approveYieldStreaming(bob, bobsShares);
+        _openYieldStream(alice, carol, alicesPrincipal);
 
-        vm.prank(alice);
-        yieldStreaming.open(carol, alicesShares, 0);
-        vm.prank(bob);
-        yieldStreaming.open(carol, bobsShares, 0);
+        uint256 bobsPrincipal = 3e18;
+        _openYieldStream(bob, carol, bobsPrincipal);
 
         // add 100% profit to vault
         _generateYield(1e18);
@@ -644,16 +984,10 @@ contract YieldStreamingTest is TestCommon {
 
     function test_claimYield_worksIfAllStreamsAreClosed() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
-        uint256 bobsPrincipal = 3e18;
-        uint256 bobsShares = _depositToVault(bob, bobsPrincipal);
-        _approveYieldStreaming(bob, bobsShares);
+        _openYieldStream(alice, carol, alicesPrincipal);
 
-        vm.prank(alice);
-        yieldStreaming.open(carol, alicesShares, 0);
-        vm.prank(bob);
-        yieldStreaming.open(carol, bobsShares, 0);
+        uint256 bobsPrincipal = 3e18;
+        _openYieldStream(bob, carol, bobsPrincipal);
 
         // add 50% profit to vault
         _generateYield(0.5e18);
@@ -895,16 +1229,15 @@ contract YieldStreamingTest is TestCommon {
 
     function test_close_emitsEvent() public {
         uint256 principal = 2e18;
-        uint256 shares = vault.previewDeposit(principal);
         _openYieldStream(alice, bob, principal);
 
         // add 100% profit to vault
         _generateYield(1e18);
 
-        uint256 yieldInShares = yieldStreaming.previewClaimYieldInShares(bob);
+        uint256 shares = vault.convertToShares(principal);
 
         vm.expectEmit(true, true, true, true);
-        emit Close(1, alice, bob, shares - yieldInShares, principal);
+        emit Close(1, alice, bob, shares, principal);
 
         vm.prank(alice);
         yieldStreaming.close(1);
@@ -960,7 +1293,7 @@ contract YieldStreamingTest is TestCommon {
         assertEq(vault.balanceOf(alice), shares, "alice's shares");
         assertEq(asset.balanceOf(alice), 0, "alice's assets");
         assertEq(yieldStreaming.receiverPrincipal(bob, 1), 0, "receiver principal");
-        assertEq(yieldStreaming.receiverShares(bob), 0, "receiver shares");
+        assertEq(yieldStreaming.receiverTotalShares(bob), 0, "receiver shares");
         assertEq(yieldStreaming.receiverTotalPrincipal(bob), 0, "receiver total principal");
     }
 
@@ -978,12 +1311,8 @@ contract YieldStreamingTest is TestCommon {
 
     function test_close_doesntAffectOtherStreamsFromTheSameStreamer() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, 1e18);
-        _approveYieldStreaming(alice, shares);
-
-        vm.startPrank(alice);
-        yieldStreaming.open(bob, shares / 2, 0);
-        yieldStreaming.open(carol, shares / 2, 0);
+        _openYieldStream(alice, bob, principal);
+        _openYieldStream(alice, carol, principal);
 
         // create a 20% profit
         _generateYield(0.2e18);
@@ -995,31 +1324,22 @@ contract YieldStreamingTest is TestCommon {
         assertTrue(carolsYield > 0, "carol's yield = 0");
         assertEq(vault.balanceOf(alice), 0, "alice's shares != 0");
 
+        vm.prank(alice);
         yieldStreaming.close(1);
 
-        assertApproxEqAbs(vault.convertToAssets(vault.balanceOf(alice)), principal / 2, 1, "alice's principal");
+        assertApproxEqAbs(vault.balanceOf(alice), vault.convertToShares(principal), 1, "alice's principal");
         assertEq(asset.balanceOf(bob), 0, "bob's assets");
-        assertEq(yieldStreaming.previewClaimYield(bob), bobsYield, "bob's yield");
+        assertApproxEqAbs(yieldStreaming.previewClaimYield(bob), bobsYield, 1, "bob's yield");
         assertEq(asset.balanceOf(carol), 0, "carol's assets");
         assertEq(yieldStreaming.previewClaimYield(carol), carolsYield, "carol's yield");
     }
 
-    function test_close_doesntAffecStreamsFromAnotherStreamer() public {
+    function test_close_doesntAffectStreamsFromAnotherStreamer() public {
         uint256 alicesPrincipal = 1e18;
-        uint256 alicesShares = _depositToVault(alice, alicesPrincipal);
-        _approveYieldStreaming(alice, alicesShares);
+        _openYieldStream(alice, carol, alicesPrincipal);
 
         uint256 bobsPrincipal = 2e18;
-        uint256 bobsShares = _depositToVault(bob, bobsPrincipal);
-        _approveYieldStreaming(bob, bobsShares);
-
-        // alice opens a stream to carol
-        vm.prank(alice);
-        yieldStreaming.open(carol, alicesShares, 0);
-
-        // bob opens a stream to carol
-        vm.prank(bob);
-        yieldStreaming.open(carol, bobsShares, 0);
+        _openYieldStream(bob, carol, bobsPrincipal);
 
         // create a 20% profit
         _generateYield(0.2e18);
@@ -1048,7 +1368,7 @@ contract YieldStreamingTest is TestCommon {
 
     function test_previewClose_returnsSharesToBeReturned() public {
         uint256 principal = 1e18;
-        uint256 shares = _depositToVault(alice, principal);
+        uint256 shares = vault.previewDeposit(principal);
         uint256 streamId = _openYieldStream(alice, bob, principal);
 
         // add 50% profit to vault
@@ -1075,8 +1395,8 @@ contract YieldStreamingTest is TestCommon {
         vm.stopPrank();
 
         assertEq(vault.balanceOf(alice), 0, "alice's shares");
-        assertEq(yieldStreaming.receiverShares(bob), (shares * 3) / 4, "receiver shares bob");
-        assertEq(yieldStreaming.receiverShares(carol), shares / 4, "receiver shares carol");
+        assertEq(yieldStreaming.receiverTotalShares(bob), (shares * 3) / 4, "receiver shares bob");
+        assertEq(yieldStreaming.receiverTotalShares(carol), shares / 4, "receiver shares carol");
     }
 
     /// *** #transfer *** ///
@@ -1172,12 +1492,26 @@ contract YieldStreamingTest is TestCommon {
 
     /// *** helpers *** ///
 
+    function _depositToVaultAndApprove(address _from, uint256 _amount) internal returns (uint256 shares) {
+        shares = _depositToVault(_from, _amount);
+        _approveYieldStreaming(_from, shares);
+    }
+
     function _depositToVault(address _from, uint256 _amount) internal returns (uint256 shares) {
         shares = _depositToVault(IERC4626(address(vault)), _from, _amount);
     }
 
     function _approveYieldStreaming(address _from, uint256 _shares) internal {
         _approve(IERC4626(address(vault)), address(yieldStreaming), _from, _shares);
+    }
+
+    function _approveAssetsAndPreviewDeposit(address _owner, uint256 _amount) private returns (uint256 shares) {
+        deal(address(asset), _owner, _amount);
+
+        vm.prank(_owner);
+        asset.approve(address(yieldStreaming), _amount);
+
+        shares = vault.previewDeposit(_amount);
     }
 
     function _generateYield(int256 _yield) internal {


### PR DESCRIPTION
- added 'openWithAssets' and 'topUpWithAssets' functions that use underlying asset of ERC4626 vault to create/top up yield streams
- updated docs
- optimized gas when opening streams