### PR TITLE
YieldStreams improvements

### DIFF
--- a/src/ERC20Streams.sol
+++ b/src/ERC20Streams.sol
@@ -36,7 +36,7 @@ contract ERC20Streams is Multicall {
     error StreamAlreadyExists();
     error StreamExpired();
     error RatePerSecondDecreased();
-    error NoTokensToClaim();
+    error NothingToClaim();
     error StreamDoesNotExist();
 
     IERC20 public immutable token;
@@ -44,7 +44,7 @@ contract ERC20Streams is Multicall {
     mapping(uint256 => Stream) public streams;
 
     constructor(IERC20 _token) {
-        address(_token).checkIsZero();
+        address(_token).revertIfZero();
 
         token = _token;
     }
@@ -81,18 +81,19 @@ contract ERC20Streams is Multicall {
      * @param _duration The duration of the stream in seconds
      */
     function open(address _receiver, uint256 _amount, uint256 _duration) public {
-        _receiver.checkIsZero();
+        _receiver.revertIfZero();
         _checkOpenStreamToSelf(_receiver);
-        _amount.checkIsZero();
-        _checkZeroDuration(_duration);
+        _amount.revertIfZero();
+        _duration.revertIfZero(ZeroDuration.selector);
 
         uint256 streamId = getStreamId(msg.sender, _receiver);
         Stream storage stream = streams[streamId];
 
         if (stream.amount > 0) {
             // If the stream already exists and isn't expired, revert
-            if (block.timestamp < stream.startTime + stream.amount.divWadUp(stream.ratePerSecond)) {
-                revert StreamAlreadyExists();
+            unchecked {
+                // stream.startTime + duration cannot overflow
+                if (block.timestamp < stream.startTime + _calculateDuration(stream)) revert StreamAlreadyExists();
             }
 
             // if is expired, transfer unclaimed tokens to receiver & emit close event
@@ -144,24 +145,29 @@ contract ERC20Streams is Multicall {
      * @param _additionalDuration The additional duration to add to the stream in seconds
      */
     function topUp(address _receiver, uint256 _additionalAmount, uint256 _additionalDuration) public {
-        _receiver.checkIsZero();
-        _additionalAmount.checkIsZero();
+        _receiver.revertIfZero();
+        _additionalAmount.revertIfZero();
 
         Stream storage stream = streams[getStreamId(msg.sender, _receiver)];
 
         _checkNonExistingStream(stream);
 
-        uint256 timeRemaining = stream.amount.divWadDown(stream.ratePerSecond);
+        uint256 duration = _calculateDuration(stream);
 
-        if (block.timestamp > stream.lastClaimTime + timeRemaining) revert StreamExpired();
+        unchecked {
+            // stream.lastClaimTime + duration cannot overflow
+            if (block.timestamp > stream.lastClaimTime + duration) revert StreamExpired();
 
-        stream.amount += _additionalAmount;
+            // not realistic to overflow
+            stream.amount += _additionalAmount;
 
-        uint256 newRatePerSecond = stream.amount.divWadUp(timeRemaining + _additionalDuration);
+            // duration + _additionalDuration cannot overflow
+            uint256 newRatePerSecond = stream.amount.divWadUp(duration + _additionalDuration);
 
-        if (newRatePerSecond < stream.ratePerSecond) revert RatePerSecondDecreased();
+            if (newRatePerSecond < stream.ratePerSecond) revert RatePerSecondDecreased();
 
-        stream.ratePerSecond = newRatePerSecond;
+            stream.ratePerSecond = newRatePerSecond;
+        }
 
         emit StreamToppedUp(msg.sender, _receiver, _additionalAmount, _additionalDuration);
 
@@ -199,14 +205,13 @@ contract ERC20Streams is Multicall {
      * @return claimed The number of tokens claimed
      */
     function claim(address _streamer, address _sendTo) public returns (uint256 claimed) {
-        _sendTo.checkIsZero();
+        _sendTo.revertIfZero();
 
         uint256 streamId = getStreamId(_streamer, msg.sender);
         Stream storage stream = streams[streamId];
 
         claimed = _previewClaim(stream);
-
-        if (claimed == 0) revert NoTokensToClaim();
+        claimed.revertIfZero(NothingToClaim.selector);
 
         if (claimed == stream.amount) {
             delete streams[streamId];
@@ -215,7 +220,11 @@ contract ERC20Streams is Multicall {
             emit StreamClosed(_streamer, msg.sender, 0, 0);
         } else {
             stream.lastClaimTime = uint128(block.timestamp);
-            stream.amount -= claimed;
+
+            unchecked {
+                // cannot underflow because claimed < stream.amount at this point
+                stream.amount -= claimed;
+            }
         }
 
         emit TokensClaimed(_streamer, msg.sender, claimed);
@@ -280,8 +289,11 @@ contract ERC20Streams is Multicall {
     function _previewClaim(Stream memory _stream) internal view returns (uint256 claimable) {
         _checkNonExistingStream(_stream);
 
-        uint256 elapsedTime = block.timestamp - _stream.lastClaimTime;
-        claimable = elapsedTime.mulWadUp(_stream.ratePerSecond);
+        unchecked {
+            // block.timestamp is always greater than or equal to _stream.lastClaimTime
+            uint256 elapsedTime = block.timestamp - _stream.lastClaimTime;
+            claimable = elapsedTime.mulWadUp(_stream.ratePerSecond);
+        }
 
         // Cap the claimalbe amount to the max available amount
         if (claimable > _stream.amount) claimable = _stream.amount;
@@ -295,20 +307,22 @@ contract ERC20Streams is Multicall {
 
         if (streamed > _stream.amount) streamed = _stream.amount;
 
-        remaining = _stream.amount - streamed;
+        unchecked {
+            remaining = _stream.amount - streamed;
+        }
 
         return (remaining, streamed);
+    }
+
+    function _calculateDuration(Stream memory _stream) internal pure returns (uint256) {
+        return _stream.amount.divWadDown(_stream.ratePerSecond);
     }
 
     function _checkOpenStreamToSelf(address _receiver) internal view {
         if (_receiver == msg.sender) revert CannotOpenStreamToSelf();
     }
 
-    function _checkZeroDuration(uint256 _duration) internal pure {
-        if (_duration == 0) revert ZeroDuration();
-    }
-
     function _checkNonExistingStream(Stream memory _stream) internal pure {
-        if (_stream.amount == 0) revert StreamDoesNotExist();
+        _stream.amount.revertIfZero(StreamDoesNotExist.selector);
     }
 }

--- a/src/YieldStreams.sol
+++ b/src/YieldStreams.sol
@@ -19,7 +19,6 @@ import {CommonErrors} from "./common/CommonErrors.sol";
  * It leverages the ERC4626 standard for tokenized vault interactions, assuming that these tokens appreciate over time, generating yield for their holders.
  */
 // TODO: update docs
-// TODO: update events
 // TODO: safe mint
 // TODO: add approved claimers
 contract YieldStreams is ERC721, Multicall {
@@ -720,7 +719,7 @@ contract YieldStreams is ERC721, Multicall {
             // id's are not going to overflow
             streamId = nextStreamId++;
 
-            _mint(_owner, streamId);
+            _safeMint(_owner, streamId);
             streamIdToReceiver[streamId] = _receiver;
 
             // not realistic to overflow

--- a/src/YieldStreams.sol
+++ b/src/YieldStreams.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import {Multicall} from "openzeppelin-contracts/utils/Multicall.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
-import {IERC2612} from "openzeppelin-contracts/interfaces/IERC2612.sol";
+import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {ERC721} from "solady/tokens/ERC721.sol";
@@ -206,7 +206,7 @@ contract YieldStreams is ERC721, Multicall {
         bytes32 r,
         bytes32 s
     ) external returns (uint256 streamId) {
-        IERC2612(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
+        IERC20Permit(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
 
         streamId = open(_receiver, _shares, _maxLossOnOpenTolerance);
     }
@@ -271,7 +271,7 @@ contract YieldStreams is ERC721, Multicall {
         bytes32 r,
         bytes32 s
     ) external returns (uint256[] memory streamIds) {
-        IERC2612(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
+        IERC20Permit(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
 
         streamIds = openMultiple(_shares, _receivers, _allocations, _maxLossOnOpenTolerance);
     }
@@ -351,7 +351,7 @@ contract YieldStreams is ERC721, Multicall {
         bytes32 r,
         bytes32 s
     ) external returns (uint256 streamId) {
-        IERC2612(vault.asset()).permit(msg.sender, address(this), _principal, deadline, v, r, s);
+        IERC20Permit(vault.asset()).permit(msg.sender, address(this), _principal, deadline, v, r, s);
 
         streamId = depositAndOpen(_receiver, _principal, _maxLossOnOpenTolerance);
     }
@@ -417,7 +417,7 @@ contract YieldStreams is ERC721, Multicall {
         bytes32 r,
         bytes32 s
     ) external returns (uint256[] memory streamIds) {
-        IERC2612(address(asset)).permit(msg.sender, address(this), _principal, deadline, v, r, s);
+        IERC20Permit(address(asset)).permit(msg.sender, address(this), _principal, deadline, v, r, s);
 
         streamIds = depositAndOpenMultiple(_principal, _receivers, _allocations, _maxLossOnOpenTolerance);
     }
@@ -460,7 +460,7 @@ contract YieldStreams is ERC721, Multicall {
         external
         returns (uint256 principal)
     {
-        IERC2612(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
+        IERC20Permit(address(vault)).permit(msg.sender, address(this), _shares, deadline, v, r, s);
 
         principal = topUp(_streamId, _shares);
     }
@@ -505,7 +505,7 @@ contract YieldStreams is ERC721, Multicall {
         bytes32 r,
         bytes32 s
     ) external returns (uint256 shares) {
-        IERC2612(address(vault.asset())).permit(msg.sender, address(this), _principal, deadline, v, r, s);
+        IERC20Permit(address(vault.asset())).permit(msg.sender, address(this), _principal, deadline, v, r, s);
 
         shares = depositAndTopUp(_streamId, _principal);
     }
@@ -592,7 +592,7 @@ contract YieldStreams is ERC721, Multicall {
         uint256 currentValue = vault.convertToAssets(receiverTotalShares[_receiver]);
 
         // if vault made a loss, there is no yield
-        yield = currentValue > principal ? currentValue - principal : 0; //184245 | 179655 | 595864
+        yield = currentValue > principal ? currentValue - principal : 0;
     }
 
     /**

--- a/src/YieldStreamsFactory.sol
+++ b/src/YieldStreamsFactory.sol
@@ -35,7 +35,7 @@ contract YieldStreamsFactory {
      * @return deployed The address of the deployed YieldStreams contract instance.
      */
     function create(IERC4626 _vault) public virtual returns (YieldStreams deployed) {
-        address(_vault).checkIsZero();
+        address(_vault).revertIfZero();
 
         if (isDeployed(_vault)) revert AlreadyDeployed();
 

--- a/src/common/CommonErrors.sol
+++ b/src/common/CommonErrors.sol
@@ -6,19 +6,38 @@ pragma solidity ^0.8.19;
  * @notice A library for commonly used errors and respective checking functions.
  */
 library CommonErrors {
-    error AmountZero();
-    error AddressZero();
+    error ZeroAmount();
+    error ZeroAddress();
 
-    function checkIsZero(uint256 _amount) internal pure {
-        if (_amount == 0) revert AmountZero();
+    function revertIfZero(uint256 _amount) internal pure {
+        if (_amount == 0) revert ZeroAmount();
     }
 
-    // TODO: figure this out
-    function checkIsZero(address _address, string memory customError) internal pure {
-        if (_address == address(0)) revert(customError);
+    function revertIfZero(uint256 _amount, bytes4 _errorSelector) internal pure {
+        if (_amount != 0) return;
+
+        // Encode the error selector with no additional arguments
+        bytes memory errorData = abi.encodeWithSelector(_errorSelector);
+        // Use assembly to revert with the encoded error data
+        assembly {
+            let errorSize := mload(errorData)
+            revert(add(errorData, 32), errorSize)
+        }
     }
 
-    function checkIsZero(address _address) internal pure {
-        if (_address == address(0)) revert AddressZero();
+    function revertIfZero(address _address) internal pure {
+        if (_address == address(0)) revert ZeroAddress();
+    }
+
+    function revertIfZero(address _address, bytes4 _errorSelector) internal pure {
+        if (_address != address(0)) return;
+
+        // Encode the error selector with no additional arguments
+        bytes memory errorData = abi.encodeWithSelector(_errorSelector);
+        // Use assembly to revert with the encoded error data
+        assembly {
+            let errorSize := mload(errorData)
+            revert(add(errorData, 32), errorSize)
+        }
     }
 }

--- a/src/common/CommonErrors.sol
+++ b/src/common/CommonErrors.sol
@@ -13,6 +13,11 @@ library CommonErrors {
         if (_amount == 0) revert AmountZero();
     }
 
+    // TODO: figure this out
+    function checkIsZero(address _address, string memory customError) internal pure {
+        if (_address == address(0)) revert(customError);
+    }
+
     function checkIsZero(address _address) internal pure {
         if (_address == address(0)) revert AddressZero();
     }

--- a/test/ERC20Streams.fork.t.sol
+++ b/test/ERC20Streams.fork.t.sol
@@ -34,7 +34,7 @@ contract ERC20StreamsTest is TestCommon {
     function test_openStream_claimTokens() public {
         uint256 duration = 2 days;
         uint256 shares = _depositToVault(scEth, alice, 1 ether);
-        _approve(scEth, address(scEthStreams), alice, shares);
+        _approve(scEth, alice, address(scEthStreams), shares);
 
         vm.prank(alice);
         scEthStreams.open(bob, shares, duration);
@@ -59,7 +59,7 @@ contract ERC20StreamsTest is TestCommon {
     function test_closeStream() public {
         uint256 duration = 2 days;
         uint256 shares = _depositToVault(scEth, alice, 1 ether);
-        _approve(scEth, address(scEthStreams), alice, shares);
+        _approve(scEth, alice, address(scEthStreams), shares);
 
         vm.prank(alice);
         scEthStreams.open(bob, shares, duration);
@@ -88,8 +88,8 @@ contract ERC20StreamsTest is TestCommon {
         uint256 bobsShares = _depositToVault(scEth, bob, 2 ether);
         uint256 bobsDuration = 4 days;
 
-        _approve(scEth, address(scEthStreams), alice, alicesShares);
-        _approve(scEth, address(scEthStreams), bob, bobsShares);
+        _approve(scEth, alice, address(scEthStreams), alicesShares);
+        _approve(scEth, bob, address(scEthStreams), bobsShares);
 
         vm.prank(alice);
         scEthStreams.open(carol, alicesShares, alicesDuration);
@@ -100,7 +100,7 @@ contract ERC20StreamsTest is TestCommon {
 
         uint256 carolsShares = _depositToVault(scEth, carol, 3 ether);
         uint256 carolsDuration = 6 days;
-        _approve(scEth, address(scEthStreams), carol, carolsShares);
+        _approve(scEth, carol, address(scEthStreams), carolsShares);
 
         vm.prank(carol);
         scEthStreams.open(alice, carolsShares, carolsDuration);

--- a/test/ERC20Streams.t.sol
+++ b/test/ERC20Streams.t.sol
@@ -36,7 +36,7 @@ contract ERC20StreamsTest is TestCommon {
      * --------------------
      */
 
-    function test_constructor_failsForAddress0() public {
+    function test_constructor_failsForZeroAddress() public {
         vm.expectRevert(CommonErrors.AddressZero.selector);
         new ERC20Streams(IERC4626(address(0)));
     }

--- a/test/ERC20Streams.t.sol
+++ b/test/ERC20Streams.t.sol
@@ -37,7 +37,7 @@ contract ERC20StreamsTest is TestCommon {
      */
 
     function test_constructor_failsForZeroAddress() public {
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         new ERC20Streams(IERC4626(address(0)));
     }
 
@@ -126,7 +126,7 @@ contract ERC20StreamsTest is TestCommon {
         uint256 shares = _depositToVault(alice, 1e18);
         _approve(alice, shares);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         vm.prank(alice);
         streams.open(address(0), shares, 1 days);
     }
@@ -135,7 +135,7 @@ contract ERC20StreamsTest is TestCommon {
         uint256 shares = _depositToVault(alice, 1e18);
         _approve(alice, shares);
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         streams.open(bob, 0, 1 days);
     }
@@ -235,7 +235,7 @@ contract ERC20StreamsTest is TestCommon {
         vm.warp(block.timestamp + 12 hours);
 
         vm.prank(bob);
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         streams.claim(alice, address(0));
     }
 
@@ -251,7 +251,7 @@ contract ERC20StreamsTest is TestCommon {
         assertApproxEqRel(vault.balanceOf(address(streams)), shares / 2, 0.0001e18, "contract balance");
         assertApproxEqRel(vault.balanceOf(bob), shares / 2, 0.0001e18, "receiver balance");
 
-        vm.expectRevert(ERC20Streams.NoTokensToClaim.selector);
+        vm.expectRevert(ERC20Streams.NothingToClaim.selector);
         vm.prank(bob);
         streams.claim(alice, bob);
 
@@ -447,7 +447,7 @@ contract ERC20StreamsTest is TestCommon {
         uint256 shares = _depositToVault(alice, 1e18);
         _approve(alice, shares);
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         streams.topUp(bob, 0, 1 days);
     }
@@ -458,7 +458,7 @@ contract ERC20StreamsTest is TestCommon {
         uint256 shares = _depositToVault(alice, 1e18);
         _approve(alice, shares);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         vm.prank(alice);
         streams.topUp(address(0), shares, 1 days);
     }
@@ -786,9 +786,9 @@ contract ERC20StreamsTest is TestCommon {
         assertEq(vault.balanceOf(carol), 0);
 
         vm.startPrank(carol);
-        vm.expectRevert(ERC20Streams.NoTokensToClaim.selector);
+        vm.expectRevert(ERC20Streams.NothingToClaim.selector);
         streams.claim(alice, carol);
-        vm.expectRevert(ERC20Streams.NoTokensToClaim.selector);
+        vm.expectRevert(ERC20Streams.NothingToClaim.selector);
         streams.claim(bob, carol);
         vm.stopPrank();
 

--- a/test/ERC20Streams.t.sol
+++ b/test/ERC20Streams.t.sol
@@ -882,7 +882,7 @@ contract ERC20StreamsTest is TestCommon {
     }
 
     function _approve(address _account, uint256 _shares) internal {
-        _approve(IERC20(address(vault)), address(streams), _account, _shares);
+        _approve(IERC20(address(vault)), _account, address(streams), _shares);
     }
 
     function _openStream(address _streamer, address _receiver, uint256 _amount, uint256 _duration)

--- a/test/YieldStreams.fork.t.sol
+++ b/test/YieldStreams.fork.t.sol
@@ -57,7 +57,7 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scEthYield.previewClaimYield(bob), expectedYield, 1, "yield before claim");
 
         vm.prank(bob);
-        scEthYield.claimYield(bob);
+        scEthYield.claimYield(bob, bob);
 
         assertEq(scEthYield.previewClaimYield(bob), 0, "yield not 0 after claim");
         assertEq(weth.balanceOf(bob), expectedYield, "bob's balance");
@@ -96,13 +96,13 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scUsdcYield.previewClaimYield(carol), carolsExpectedYield, 1, "carol's yield before claim");
 
         vm.prank(bob);
-        scUsdcYield.claimYield(bob);
+        scUsdcYield.claimYield(bob, bob);
 
         assertEq(scUsdcYield.previewClaimYield(bob), 0, "bob's yield not 0 after claim");
         assertEq(usdc.balanceOf(bob), bobsExpectedYield, "bob's balance");
 
         vm.prank(carol);
-        scUsdcYield.claimYield(carol);
+        scUsdcYield.claimYield(carol, carol);
         assertEq(scUsdcYield.previewClaimYield(carol), 0, "carol's yield not 0 after claim");
         assertApproxEqAbs(usdc.balanceOf(carol), carolsExpectedYield, 1, "carol's balance");
 
@@ -131,7 +131,7 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scEthYield.previewClaimYield(bob), expectedYield, 1, "yield");
 
         vm.prank(bob);
-        scEthYield.claimYield(bob);
+        scEthYield.claimYield(bob, bob);
         assertEq(scEthYield.previewClaimYield(bob), 0, "yield not 0 after claim");
 
         uint256 sharesBeforeTopUp = scEthYield.receiverTotalShares(bob);
@@ -181,7 +181,7 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scEthYield.previewClaimYield(carol), expectedYield, 1, "carol's yield before claim");
 
         vm.prank(carol);
-        scEthYield.claimYield(carol);
+        scEthYield.claimYield(carol, carol);
 
         assertEq(scEthYield.previewClaimYield(carol), 0, "carol's yield not 0 after claim");
         assertApproxEqAbs(weth.balanceOf(carol), expectedYield, 1, "carol's assets");
@@ -208,7 +208,7 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scUsdcYield.previewClaimYield(bob), expectedYield, 1, "yield");
 
         vm.prank(bob);
-        uint256 claimed = scUsdcYield.claimYield(bob);
+        uint256 claimed = scUsdcYield.claimYield(bob, bob);
 
         assertEq(scUsdcYield.previewClaimYield(bob), 0, "yield not 0 after claim");
         assertEq(usdc.balanceOf(bob), claimed, "bob's assets");
@@ -293,7 +293,7 @@ contract YieldStreamsForkTest is TestCommon {
         assertApproxEqAbs(scEthYield.previewClaimYield(bob), expectedYield, 1, "yieldFor bob");
 
         vm.prank(bob);
-        scEthYield.claimYield(bob);
+        scEthYield.claimYield(bob, bob);
 
         assertEq(scEthYield.previewClaimYield(bob), 0, "yieldFor bob");
         assertEq(weth.balanceOf(bob), expectedYield, "bob's balance");
@@ -324,7 +324,7 @@ contract YieldStreamsForkTest is TestCommon {
         scEthYield.close(1);
 
         vm.prank(carol);
-        scEthYield.claimYield(carol);
+        scEthYield.claimYield(carol, carol);
 
         assertEq(scEthYield.previewClaimYield(carol), 0, "carol yield not 0 after claim");
         assertApproxEqAbs(weth.balanceOf(carol), expectedYield, 1, "carol's balance");

--- a/test/YieldStreams.fork.t.sol
+++ b/test/YieldStreams.fork.t.sol
@@ -40,7 +40,7 @@ contract YieldStreamsForkTest is TestCommon {
 
     function test_open() public {
         uint256 shares = _depositToVault(scEth, alice, 1 ether);
-        _approve(scEth, address(scEthYield), alice, shares);
+        _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
         scEthYield.open(bob, shares, 0);
@@ -67,7 +67,7 @@ contract YieldStreamsForkTest is TestCommon {
         // alice opens yield streams to bob and carol
         // principal = 3000 USDC
         uint256 shares = _depositToVault(scUsdc, alice, 3000e6);
-        _approve(scUsdc, address(scUsdcYield), alice, shares);
+        _approve(scUsdc, alice, address(scUsdcYield), shares);
 
         uint256 bobsShares = shares / 3;
         uint256 carolsShares = shares - bobsShares;
@@ -119,7 +119,7 @@ contract YieldStreamsForkTest is TestCommon {
 
     function test_topUp() public {
         uint256 shares = _depositToVault(scEth, alice, 1 ether);
-        _approve(scEth, address(scEthYield), alice, shares);
+        _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
         scEthYield.open(bob, shares, 0);
@@ -137,7 +137,7 @@ contract YieldStreamsForkTest is TestCommon {
         uint256 sharesBeforeTopUp = scEthYield.receiverTotalShares(bob);
 
         uint256 topUpShares = _depositToVault(scEth, alice, 2 ether);
-        _approve(scEth, address(scEthYield), alice, topUpShares);
+        _approve(scEth, alice, address(scEthYield), topUpShares);
 
         vm.prank(alice);
         scEthYield.topUp(1, topUpShares);
@@ -156,13 +156,13 @@ contract YieldStreamsForkTest is TestCommon {
         // alice and bob open yield streams to carol
         uint256 alicesPrincipal = 1 ether;
         uint256 alicesShares = _depositToVault(scEth, alice, alicesPrincipal);
-        _approve(scEth, address(scEthYield), alice, alicesShares);
+        _approve(scEth, alice, address(scEthYield), alicesShares);
         vm.prank(alice);
         scEthYield.open(carol, alicesShares, 0);
 
         uint256 bobsPrincipal = 2 ether;
         uint256 bobsShares = _depositToVault(scEth, bob, bobsPrincipal);
-        _approve(scEth, address(scEthYield), bob, bobsShares);
+        _approve(scEth, bob, address(scEthYield), bobsShares);
         vm.prank(bob);
         scEthYield.open(carol, bobsShares, 0);
 
@@ -218,7 +218,7 @@ contract YieldStreamsForkTest is TestCommon {
     function test_depositAndTopUp() public {
         uint256 principal = 1000e6;
         uint256 shares = _depositToVault(scUsdc, alice, principal);
-        _approve(scUsdc, address(scUsdcYield), alice, shares);
+        _approve(scUsdc, alice, address(scUsdcYield), shares);
 
         vm.prank(alice);
         uint256 streamId = scUsdcYield.open(bob, shares, 0);
@@ -263,7 +263,7 @@ contract YieldStreamsForkTest is TestCommon {
     function test_close() public {
         uint256 principal = 1 ether;
         uint256 shares = _depositToVault(scEth, alice, principal);
-        _approve(scEth, address(scEthYield), alice, shares);
+        _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
         scEthYield.open(bob, shares, 0);
@@ -303,14 +303,14 @@ contract YieldStreamsForkTest is TestCommon {
         // alice and bob open yield streams to carol
         uint256 alicesPrincipal = 1 ether;
         uint256 alicesShares = _depositToVault(scEth, alice, alicesPrincipal);
-        _approve(scEth, address(scEthYield), alice, alicesShares);
+        _approve(scEth, alice, address(scEthYield), alicesShares);
 
         vm.prank(alice);
         scEthYield.open(carol, alicesShares, 0);
 
         uint256 bobsDepositAmount = 2 ether;
         uint256 bobsShares = _depositToVault(scEth, bob, bobsDepositAmount);
-        _approve(scEth, address(scEthYield), bob, bobsShares);
+        _approve(scEth, bob, address(scEthYield), bobsShares);
 
         vm.prank(bob);
         scEthYield.open(carol, bobsShares, 0);
@@ -340,7 +340,7 @@ contract YieldStreamsForkTest is TestCommon {
     function test_multicall_openTwoStreams() public {
         uint256 principal = 1000e6;
         uint256 shares = _depositToVault(scUsdc, alice, principal);
-        _approve(scUsdc, address(scUsdcYield), alice, shares);
+        _approve(scUsdc, alice, address(scUsdcYield), shares);
 
         bytes[] memory callData = new bytes[](2);
 
@@ -364,7 +364,7 @@ contract YieldStreamsForkTest is TestCommon {
     function test_openMultiple_openTwoStreams() public {
         uint256 principal = 1000e6;
         uint256 shares = _depositToVault(scUsdc, alice, principal);
-        _approve(scUsdc, address(scUsdcYield), alice, shares);
+        _approve(scUsdc, alice, address(scUsdcYield), shares);
 
         address[] memory receivers = new address[](2);
         uint256[] memory allocations = new uint256[](2);

--- a/test/YieldStreams.fork.t.sol
+++ b/test/YieldStreams.fork.t.sol
@@ -43,7 +43,7 @@ contract YieldStreamsForkTest is TestCommon {
         _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
-        scEthYield.open(bob, shares, 0);
+        scEthYield.open(alice, bob, shares, 0);
 
         assertEq(scEth.balanceOf(address(scEthYield)), shares, "contract's balance");
         assertEq(scEthYield.receiverTotalShares(bob), shares, "receiverShares");
@@ -73,8 +73,8 @@ contract YieldStreamsForkTest is TestCommon {
         uint256 carolsShares = shares - bobsShares;
 
         vm.startPrank(alice);
-        scUsdcYield.open(bob, bobsShares, 0);
-        scUsdcYield.open(carol, carolsShares, 0);
+        scUsdcYield.open(alice, bob, bobsShares, 0);
+        scUsdcYield.open(alice, carol, carolsShares, 0);
         vm.stopPrank();
 
         assertEq(scUsdc.balanceOf(address(scUsdcYield)), shares, "contract's balance");
@@ -122,7 +122,7 @@ contract YieldStreamsForkTest is TestCommon {
         _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
-        scEthYield.open(bob, shares, 0);
+        scEthYield.open(alice, bob, shares, 0);
 
         _generateYield(scEth, 0.05e18); // 5%
 
@@ -158,13 +158,13 @@ contract YieldStreamsForkTest is TestCommon {
         uint256 alicesShares = _depositToVault(scEth, alice, alicesPrincipal);
         _approve(scEth, alice, address(scEthYield), alicesShares);
         vm.prank(alice);
-        scEthYield.open(carol, alicesShares, 0);
+        scEthYield.open(alice, carol, alicesShares, 0);
 
         uint256 bobsPrincipal = 2 ether;
         uint256 bobsShares = _depositToVault(scEth, bob, bobsPrincipal);
         _approve(scEth, bob, address(scEthYield), bobsShares);
         vm.prank(bob);
-        scEthYield.open(carol, bobsShares, 0);
+        scEthYield.open(bob, carol, bobsShares, 0);
 
         assertEq(scEth.balanceOf(address(scEthYield)), alicesShares + bobsShares, "contract's balance");
         assertEq(scEthYield.receiverTotalShares(carol), alicesShares + bobsShares, "receiverShares");
@@ -195,7 +195,7 @@ contract YieldStreamsForkTest is TestCommon {
         usdc.approve(address(scUsdcYield), principal);
 
         vm.prank(alice);
-        scUsdcYield.depositAndOpen(bob, principal, 0);
+        scUsdcYield.depositAndOpen(alice, bob, principal, 0);
 
         assertEq(scUsdc.balanceOf(address(scUsdcYield)), shares, "contract's balance");
         assertEq(scUsdcYield.receiverTotalShares(bob), shares, "receiverShares");
@@ -221,7 +221,7 @@ contract YieldStreamsForkTest is TestCommon {
         _approve(scUsdc, alice, address(scUsdcYield), shares);
 
         vm.prank(alice);
-        uint256 streamId = scUsdcYield.open(bob, shares, 0);
+        uint256 streamId = scUsdcYield.open(alice, bob, shares, 0);
 
         uint256 firstYield = 0.05e18; // 5%
         _generateYield(scUsdc, int256(firstYield)); // 5%
@@ -266,7 +266,7 @@ contract YieldStreamsForkTest is TestCommon {
         _approve(scEth, alice, address(scEthYield), shares);
 
         vm.prank(alice);
-        scEthYield.open(bob, shares, 0);
+        scEthYield.open(alice, bob, shares, 0);
 
         assertEq(scEth.balanceOf(address(scEthYield)), shares, "contract's balance");
         assertEq(scEthYield.receiverTotalShares(bob), shares, "receiverShares");
@@ -306,14 +306,14 @@ contract YieldStreamsForkTest is TestCommon {
         _approve(scEth, alice, address(scEthYield), alicesShares);
 
         vm.prank(alice);
-        scEthYield.open(carol, alicesShares, 0);
+        scEthYield.open(alice, carol, alicesShares, 0);
 
         uint256 bobsDepositAmount = 2 ether;
         uint256 bobsShares = _depositToVault(scEth, bob, bobsDepositAmount);
         _approve(scEth, bob, address(scEthYield), bobsShares);
 
         vm.prank(bob);
-        scEthYield.open(carol, bobsShares, 0);
+        scEthYield.open(bob, carol, bobsShares, 0);
 
         uint256 profitPct = 0.05e18; // 5%
         uint256 expectedYield = (alicesPrincipal + bobsDepositAmount).mulWadDown(profitPct);
@@ -344,8 +344,8 @@ contract YieldStreamsForkTest is TestCommon {
 
         bytes[] memory callData = new bytes[](2);
 
-        callData[0] = abi.encodeWithSelector(YieldStreams.open.selector, bob, shares / 2, 0);
-        callData[1] = abi.encodeWithSelector(YieldStreams.open.selector, carol, shares / 2, 0);
+        callData[0] = abi.encodeCall(YieldStreams.open, (alice, bob, shares / 2, 0));
+        callData[1] = abi.encodeCall(YieldStreams.open, (alice, carol, shares / 2, 0));
 
         vm.prank(alice);
         bytes[] memory results = scUsdcYield.multicall(callData);
@@ -375,7 +375,7 @@ contract YieldStreamsForkTest is TestCommon {
         allocations[1] = 0.5e18;
 
         vm.prank(alice);
-        uint256[] memory streamIds = scUsdcYield.openMultiple(shares, receivers, allocations, 0);
+        uint256[] memory streamIds = scUsdcYield.openMultiple(alice, shares, receivers, allocations, 0);
 
         assertApproxEqAbs(scUsdc.balanceOf(address(scUsdcYield)), shares, 1, "contract's balance");
         assertEq(scUsdcYield.receiverTotalShares(bob), shares / 2, "bob's receiverShares");
@@ -415,7 +415,7 @@ contract YieldStreamsForkTest is TestCommon {
         allocations[1] = 0.3e18;
 
         vm.prank(dave);
-        scUsdcYield.depositAndOpenMultipleUsingPermit(principal, receivers, allocations, 0, deadline, v, r, s);
+        scUsdcYield.depositAndOpenMultipleUsingPermit(dave, principal, receivers, allocations, 0, deadline, v, r, s);
 
         // add some yield
         _generateYield(scUsdc, 0.1e18); // 10%

--- a/test/YieldStreams.t.sol
+++ b/test/YieldStreams.t.sol
@@ -2149,7 +2149,7 @@ contract YieldStreamsTest is TestCommon {
     }
 
     function _approveYieldStreamsContract(address _from, uint256 _shares) internal {
-        _approve(IERC4626(address(vault)), address(ys), _from, _shares);
+        _approve(IERC4626(address(vault)), _from, address(ys), _shares);
     }
 
     function _approveAssetsAndPreviewDeposit(address _owner, uint256 _amount) private returns (uint256 shares) {

--- a/test/YieldStreams.t.sol
+++ b/test/YieldStreams.t.sol
@@ -66,8 +66,7 @@ contract YieldStreamsTest is TestCommon {
         // nft ids start from 1
         assertEq(ys.nextStreamId(), 1, "next stream id");
         assertEq(address(ys.asset()), address(asset), "underlying asset");
-        // vault is not allowed to transfer assets by default
-        assertEq(asset.allowance(address(ys), address(vault)), 0, "allowance");
+        assertEq(asset.allowance(address(ys), address(vault)), type(uint256).max, "asset allowance");
     }
 
     /*

--- a/test/YieldStreams.t.sol
+++ b/test/YieldStreams.t.sol
@@ -2691,7 +2691,6 @@ contract YieldStreamsTest is TestCommon {
         assertEq(ys.tokenURI(streamId), string.concat("ipfs://", cid), "token URI");
     }
 
-
     /*
      * --------------------
      *     #multicall
@@ -2762,7 +2761,6 @@ contract YieldStreamsTest is TestCommon {
         assertEq(ys.balanceOf(carol), 0, "carol's nfts");
         assertApproxEqAbs(ys.previewClaimYield(bob), 1e18 / 2, 1, "bob's yield");
     }
-
 
     /*
      * --------------------

--- a/test/YieldStreams.t.sol
+++ b/test/YieldStreams.t.sol
@@ -79,7 +79,7 @@ contract YieldStreamsTest is TestCommon {
         _depositToVaultAndApprove(alice, 1e18);
 
         vm.startPrank(alice);
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         ys.open(alice, bob, 0, 0);
     }
 
@@ -87,7 +87,7 @@ contract YieldStreamsTest is TestCommon {
         uint256 shares = _depositToVaultAndApprove(alice, 1e18);
 
         vm.startPrank(alice);
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.ReceiverZeroAddress.selector);
         ys.open(alice, address(0), shares, 0);
     }
 
@@ -95,7 +95,7 @@ contract YieldStreamsTest is TestCommon {
         uint256 shares = _depositToVaultAndApprove(alice, 1e18);
 
         vm.startPrank(alice);
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.OwnerZeroAddress.selector);
         ys.open(address(0), bob, shares, 0);
     }
 
@@ -300,7 +300,7 @@ contract YieldStreamsTest is TestCommon {
         uint256[] memory allocations = new uint256[](1);
         allocations[0] = 0;
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         ys.openMultiple(alice, 0, receivers, allocations, 0);
     }
@@ -314,7 +314,7 @@ contract YieldStreamsTest is TestCommon {
         uint256[] memory allocations = new uint256[](1);
         allocations[0] = 1e18;
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.OwnerZeroAddress.selector);
         vm.prank(alice);
         ys.openMultiple(address(0), 1e18, receivers, allocations, 0);
     }
@@ -359,7 +359,7 @@ contract YieldStreamsTest is TestCommon {
         allocations[0] = 0.1e18;
         allocations[1] = 0.9e18;
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.ReceiverZeroAddress.selector);
         vm.prank(alice);
         ys.openMultiple(alice, shares, receivers, allocations, 0);
     }
@@ -375,7 +375,7 @@ contract YieldStreamsTest is TestCommon {
         allocations[0] = 0.1e18;
         allocations[1] = 0;
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         ys.openMultiple(alice, shares, receivers, allocations, 0);
     }
@@ -659,7 +659,7 @@ contract YieldStreamsTest is TestCommon {
         uint256 principal = 1e18;
         _approveAssetsAndPreviewDeposit(alice, principal);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.ReceiverZeroAddress.selector);
         vm.prank(alice);
         ys.depositAndOpen(alice, address(0), principal, 0);
     }
@@ -668,7 +668,7 @@ contract YieldStreamsTest is TestCommon {
         uint256 principal = 1e18;
         _approveAssetsAndPreviewDeposit(alice, principal);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.OwnerZeroAddress.selector);
         vm.prank(alice);
         ys.depositAndOpen(address(0), bob, principal, 0);
     }
@@ -873,9 +873,23 @@ contract YieldStreamsTest is TestCommon {
         uint256[] memory allocations = new uint256[](1);
         allocations[0] = 1e18;
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         ys.depositAndOpenMultiple(alice, 0, receivers, allocations, 0);
+    }
+
+    function test_depositAndOpenMultiple_failsIfOwnerIsZeroAddress() public {
+        _approveAssetsAndPreviewDeposit(alice, 1e18);
+
+        address[] memory receivers = new address[](1);
+        receivers[0] = bob;
+
+        uint256[] memory allocations = new uint256[](1);
+        allocations[0] = 1e18;
+
+        vm.expectRevert(YieldStreams.OwnerZeroAddress.selector);
+        vm.prank(alice);
+        ys.depositAndOpenMultiple(address(0), 1e18, receivers, allocations, 0);
     }
 
     function test_depositAndOpenMultiple_failsIfArrayLengthsDontMatch() public {
@@ -918,7 +932,7 @@ contract YieldStreamsTest is TestCommon {
         allocations[0] = 0.1e18;
         allocations[1] = 0.9e18;
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(YieldStreams.ReceiverZeroAddress.selector);
         vm.prank(alice);
         ys.depositAndOpenMultiple(alice, principal, receivers, allocations, 0);
     }
@@ -935,7 +949,7 @@ contract YieldStreamsTest is TestCommon {
         allocations[0] = 0.1e18;
         allocations[1] = 0;
 
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         vm.prank(alice);
         ys.depositAndOpenMultiple(alice, principal, receivers, allocations, 0);
     }
@@ -1203,7 +1217,7 @@ contract YieldStreamsTest is TestCommon {
         _depositToVaultAndApprove(alice, 1e18);
 
         vm.prank(alice);
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         ys.topUp(streamId, 0);
     }
 
@@ -1364,7 +1378,7 @@ contract YieldStreamsTest is TestCommon {
         _approveAssetsAndPreviewDeposit(alice, 1e18);
 
         vm.prank(alice);
-        vm.expectRevert(CommonErrors.AmountZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAmount.selector);
         ys.depositAndTopUp(streamId, 0);
     }
 
@@ -1660,7 +1674,7 @@ contract YieldStreamsTest is TestCommon {
         // add 50% profit to vault
         _generateYield(0.5e18);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         vm.prank(bob);
         ys.claimYield(address(0));
     }
@@ -1821,7 +1835,7 @@ contract YieldStreamsTest is TestCommon {
         // add 50% profit to vault
         _generateYield(0.5e18);
 
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         vm.prank(bob);
         ys.claimYieldInShares(address(0));
     }

--- a/test/YieldStreamsFactory.t.sol
+++ b/test/YieldStreamsFactory.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import "forge-std/Test.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {MockERC4626} from "solmate/test/utils/mocks/MockERC4626.sol";
@@ -9,8 +8,9 @@ import {MockERC4626} from "solmate/test/utils/mocks/MockERC4626.sol";
 import {CommonErrors} from "src/common/CommonErrors.sol";
 import {YieldStreamsFactory} from "src/YieldStreamsFactory.sol";
 import {YieldStreams} from "src/YieldStreams.sol";
+import {TestCommon} from "./common/TestCommon.sol";
 
-contract YieldStreamsFactoryTest is Test {
+contract YieldStreamsFactoryTest is TestCommon {
     YieldStreamsFactory public factory;
     MockERC20 public asset;
     IERC4626 public vault;
@@ -46,15 +46,13 @@ contract YieldStreamsFactoryTest is Test {
         assertEq(address(deployed.vault()), address(vault), "vault");
 
         // open yield stream to confirm correcntess
-        asset.mint(address(this), 1 ether);
-        asset.approve(address(vault), 1 ether);
-        uint256 shares = vault.deposit(1 ether, address(this));
-        vault.approve(address(deployed), shares);
-        address receiver = address(0x02);
+        uint256 shares = _depositToVaultAndApprove(vault, alice, address(deployed), 1000);
 
-        deployed.open(address(this), receiver, shares, 0);
+        vm.prank(alice);
+        deployed.open(alice, bob, shares, 0);
 
         assertEq(vault.balanceOf(address(deployed)), shares, "stream shares");
+        assertEq(vault.balanceOf(alice), 0, "alice's shares");
     }
 
     function test_create_emitsEvent() public {

--- a/test/YieldStreamsFactory.t.sol
+++ b/test/YieldStreamsFactory.t.sol
@@ -25,7 +25,7 @@ contract YieldStreamsFactoryTest is Test {
     }
 
     function test_create_failsIfVaultIsZero() public {
-        vm.expectRevert(CommonErrors.AddressZero.selector);
+        vm.expectRevert(CommonErrors.ZeroAddress.selector);
         factory.create(IERC4626(address(0)));
     }
 

--- a/test/YieldStreamsFactory.t.sol
+++ b/test/YieldStreamsFactory.t.sol
@@ -52,7 +52,7 @@ contract YieldStreamsFactoryTest is Test {
         vault.approve(address(deployed), shares);
         address receiver = address(0x02);
 
-        deployed.open(receiver, shares, 0);
+        deployed.open(address(this), receiver, shares, 0);
 
         assertEq(vault.balanceOf(address(deployed)), shares, "stream shares");
     }

--- a/test/common/TestCommon.sol
+++ b/test/common/TestCommon.sol
@@ -25,12 +25,12 @@ abstract contract TestCommon is Test {
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    function _signPermit(uint256 ownerKey, address _token, address _spender, uint256 _amount, uint256 _deadline)
+    function _signPermit(uint256 _ownerKey, address _token, address _spender, uint256 _amount, uint256 _deadline)
         internal
         view
         returns (uint8 v, bytes32 r, bytes32 s)
     {
-        address owner = vm.addr(ownerKey);
+        address owner = vm.addr(_ownerKey);
         bytes32 data = keccak256(
             abi.encodePacked(
                 "\x19\x01",
@@ -41,7 +41,7 @@ abstract contract TestCommon is Test {
             )
         );
 
-        return vm.sign(ownerKey, data);
+        return vm.sign(_ownerKey, data);
     }
 
     function _depositToVault(IERC4626 _vault, address _from, uint256 _amount) internal returns (uint256 shares) {

--- a/test/common/TestCommon.sol
+++ b/test/common/TestCommon.sol
@@ -7,9 +7,13 @@ import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
+import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
 
 abstract contract TestCommon is Test {
     using FixedPointMathLib for uint256;
+
+    address constant admin = address(0x01);
+    address constant keeper = address(0x02);
 
     address constant alice = address(0x06);
     address constant bob = address(0x07);
@@ -21,26 +25,56 @@ abstract contract TestCommon is Test {
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    function _depositToVault(IERC4626 _vault, address _from, uint256 _amount) internal returns (uint256 shares) {
-        vm.startPrank(_from);
+    function _signPermit(uint256 ownerKey, address _token, address _spender, uint256 _amount, uint256 _deadline)
+        internal
+        view
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        address owner = vm.addr(ownerKey);
+        bytes32 data = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                IERC20Permit(_token).DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(PERMIT_TYPEHASH, owner, _spender, _amount, IERC20Permit(_token).nonces(owner), _deadline)
+                )
+            )
+        );
 
-        address asset = _vault.asset();
-
-        deal(asset, _from, _amount);
-        IERC20(asset).approve(address(_vault), _amount);
-
-        shares = _vault.deposit(_amount, _from);
-
-        vm.stopPrank();
+        return vm.sign(ownerKey, data);
     }
 
-    function _approve(IERC20 _token, address _spender, address _from, uint256 _shares) internal {
+    function _depositToVault(IERC4626 _vault, address _from, uint256 _amount) internal returns (uint256 shares) {
+        _dealAndApprove(IERC20(_vault.asset()), _from, address(_vault), _amount);
+
         vm.prank(_from);
-        _token.approve(address(_spender), _shares);
+        shares = _vault.deposit(_amount, _from);
+    }
+
+    function _approve(IERC20 _token, address _owner, address _spender, uint256 _amount) internal {
+        vm.prank(_owner);
+        _token.approve(address(_spender), _amount);
+    }
+
+    function _depositToVaultAndApprove(IERC4626 _vault, address _from, address _spender, uint256 _amount)
+        internal
+        returns (uint256 shares)
+    {
+        shares = _depositToVault(_vault, _from, _amount);
+        _approve(IERC20(_vault), _from, _spender, shares);
+    }
+
+    function _dealAndApprove(IERC20 _token, address _owner, address _spender, uint256 _amount) internal {
+        deal(address(_token), _owner, _amount);
+        _approve(_token, _owner, _spender, _amount);
+    }
+
+    function _shiftTime(uint256 _period) internal {
+        vm.warp(block.timestamp + _period);
     }
 
     function _generateYield(IERC4626 _vault, int256 _percent) internal {
-        require(_percent >= -1e18 && _percent <= 1e18, "TestCommon: percent must be inside -1e18 and 1e18");
+        require(_percent >= -1e18, "TestCommon: percent must greater than or equal to -1e18");
         require(_percent != 0, "TestCommon: percent must be non-zero");
 
         IERC20 asset = IERC20(_vault.asset());

--- a/test/mock/NFTHolderMock.sol
+++ b/test/mock/NFTHolderMock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.19;
+
+import {IERC721Receiver} from "openzeppelin-contracts/token/ERC721/IERC721Receiver.sol";
+
+contract NFTHolderMock is IERC721Receiver {
+    function onERC721Received(address, address, uint256, bytes memory) external pure override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}


### PR DESCRIPTION
- using solady's SafeTransferLib to facilitate token transfers
- added owner parameter to stream opening functions
- using _safeMint() from ERC721 to allow only contracts that implement IERC721Receiver as owners 
- allowed for approved ERC721 operators to manage streams (topUp/close/setCID)
- allow for approved claimers to claim yield on the receiver's behalf
- add stream (ERC721 token) metadata as IPFS CIDs (Content Identifier)
- docs update